### PR TITLE
Speed up response-calculation with interpolation-option

### DIFF
--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -177,7 +177,13 @@ class ResponseStage(ComparingObject):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
+        """
+        :param frequencies: Frequency range to get resp curve over
+        :param fast: Dummy argument to make function similar to
+                     get_response-functions for other stage-types.
+        :return: The curve describing this response stage
+        """
         # if a response stage isn't a subclass then it's likely a gain stage.
         return np.ones_like(frequencies) * self.stage_gain
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1070,7 +1070,8 @@ class Response(ComparingObject):
             raise ValueError("Unknown unit '%s'." % unit)
 
     def get_response_for_window_size(self, t_samp, nfft, output="VEL",
-                                     start_stage=None, end_stage=None):
+                                     start_stage=None, end_stage=None,
+                                     fast=True):
         """
         Returns frequency response and corresponding frequencies for
         the given sample rate delta and FFT window size
@@ -1108,7 +1109,8 @@ class Response(ComparingObject):
             freqs = np.linspace(0, fy, int(nfft // 2) + 1).astype(np.float64)
 
         response = self.get_response(
-            freqs, output=output, start_stage=start_stage, end_stage=end_stage)
+            freqs, output=output, start_stage=start_stage, end_stage=end_stage,
+            fast=fast)
         return response, freqs
 
     def get_response(self, frequencies, output="velocity", start_stage=None,

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -340,6 +340,8 @@ class PolesZerosResponseStage(ResponseStage):
         Produce the response curve from this stage's data for a given
         range of frequencies
         :param frequencies: Frequency range to get resp curve over
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         :return: The curve describing this response stage
         """
         # Has to be imported here for now to avoid circular imports.
@@ -361,9 +363,9 @@ class PolesZerosResponseStage(ResponseStage):
             amp = np.abs(resp)
             phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
             amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=2)(frequencies)
+                resp_frequencies, amp, k=2)(frequencies)
             phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, phase, k=2)(frequencies)
+                resp_frequencies, phase, k=2)(frequencies)
             final_resp = np.zeros_like(frequencies) + 0j
             final_resp.real = amp * np.cos(phase)
             final_resp.imag = amp * np.sin(phase)
@@ -547,6 +549,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         Produce the response curve from this coefficient
         response stage for a range of frequencies
         :param frequencies: Frequency range to get resp curve over
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         :return: The curve describing this response stage
         """
         # Decimation blockette, e.g. gain only!
@@ -580,7 +584,9 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                w = resp_frequencies  # rename to be concise and match conventions
+                
+                # rename to be concise and match conventions
+                w = resp_frequencies
 
                 resp = np.zeros_like(w) + 0j
                 for idx, num in enumerate(self.numerator):
@@ -810,7 +816,10 @@ class FIRResponseStage(ResponseStage):
 
     def get_response(self, frequencies, fast=True):
         """
-        Given Computes the 
+        Given Computes the
+        :param frequencies: Discrete frequencies to calculate response for. 
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -351,13 +351,13 @@ class PolesZerosResponseStage(ResponseStage):
                                            10000, dtype=np.float64)
         else:
             resp_frequencies = frequencies
-            
+
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
             zeros=np.array(self._zeros, dtype=np.complex128),
             scale_fac=self.normalization_factor,
             frequencies=resp_frequencies, freq=False) * self.stage_gain
-        
+
         # If required, do interpolation of amplitude and phase of the response
         if len(frequencies) > 10000 and fast:
             amp = np.abs(resp)
@@ -371,7 +371,7 @@ class PolesZerosResponseStage(ResponseStage):
             final_resp.imag = amp * np.sin(phase)
         else:
             final_resp = resp
-        
+
         return final_resp
 
     def calc_normalization_factor(self):
@@ -559,7 +559,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
-        
+
         # Check if interpolation is required so save time for long traces.
         if len(frequencies) > 10000 and fast:
             resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
@@ -584,7 +584,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                
+
                 # rename to be concise and match conventions
                 w = resp_frequencies
 
@@ -604,8 +604,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         elif self.cf_transfer_function_type == "ANALOG (RADIANS/SECOND)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=resp_frequencies\
-                    / (np.pi * 2.0))[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies
+                / (np.pi * 2.0))[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency / (np.pi * 2.0)])[1])
@@ -634,7 +634,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # evalresp does this and thus so do we.
         if self.cf_transfer_function_type != 'DIGITAL':
             amp *= self.stage_gain / gain_freq_amp
-        
+
         # If "fast", then interpolate the amplitude and phase onto the
         # originally requested frequencies.
         if len(frequencies) > 10000 and fast:
@@ -817,7 +817,7 @@ class FIRResponseStage(ResponseStage):
     def get_response(self, frequencies, fast=True):
         """
         Given Computes the
-        :param frequencies: Discrete frequencies to calculate response for. 
+        :param frequencies: Discrete frequencies to calculate response for.
         :param fast: Indicates whether to speed up calculation through
             interpolation.
         """

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1116,6 +1116,10 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
+        :type fast: bool
+        :param fast: When set to True (default), then the calculation of the
+            response for a large number of frequencies is sped up through
+            interpolation. Relevant for traces with >10000 samples.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """
@@ -1140,10 +1144,10 @@ class Response(ComparingObject):
         stages = self.response_stages[slice(start_stage, end_stage)]
         # map 0j here to ensure the curve is complex values
         # which it may not be if we start on a gain stage
-        resp = stages[0].get_response(frequencies=frequencies) + 0j
+        resp = stages[0].get_response(frequencies=frequencies, fast=fast) + 0j
         for stage in stages[1:]:
             try:
-                resp *= stage.get_response(frequencies=frequencies)
+                resp *= stage.get_response(frequencies=frequencies, fast=fast)
             except AttributeError:
                 raise NotImplementedError
 
@@ -1152,9 +1156,9 @@ class Response(ComparingObject):
         if start_stage == 0 and end_stage is None:
             f = np.array([self.instrument_sensitivity.frequency])
             stages = self.response_stages[slice(start_stage, end_stage)]
-            ref = stages[0].get_response(frequencies=f)
+            ref = stages[0].get_response(frequencies=f, fast=fast)
             for stage in stages[1:]:
-                ref *= stage.get_response(frequencies=f)
+                ref *= stage.get_response(frequencies=f, fast=fast)
             resp *= self.instrument_sensitivity.value / np.abs(ref[0])
 
         # By now the response is in the input units of the first stage.

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -808,7 +808,10 @@ class FIRResponseStage(ResponseStage):
             new_values.append(x)
         self._coefficients = new_values
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
+        """
+        Given Computes the 
+        """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
             return np.ones_like(frequencies) * self.stage_gain

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -335,7 +335,7 @@ class PolesZerosResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
         """
         Produce the response curve from this stage's data for a given
         range of frequencies
@@ -344,11 +344,33 @@ class PolesZerosResponseStage(ResponseStage):
         """
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
-        return paz_to_freq_resp(
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+        else:
+            resp_frequencies = frequencies
+            
+        resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
             zeros=np.array(self._zeros, dtype=np.complex128),
             scale_fac=self.normalization_factor,
-            frequencies=frequencies, freq=False) * self.stage_gain
+            frequencies=resp_frequencies, freq=False) * self.stage_gain
+        
+        # If required, do interpolation of amplitude and phase of the response
+        if len(frequencies) > 10000 and fast:
+            amp = np.abs(resp)
+            phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=2)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
+            final_resp.real = amp * np.cos(phase)
+            final_resp.imag = amp * np.sin(phase)
+        else:
+            final_resp = resp
+        
+        return final_resp
 
     def calc_normalization_factor(self):
         """
@@ -520,7 +542,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
         """
         Produce the response curve from this coefficient
         response stage for a range of frequencies
@@ -533,6 +555,13 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
+        
+        # Check if interpolation is required so save time for long traces.
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+        else:
+            resp_frequencies = frequencies
 
         # While most cases we expect this to represent a Bkt. 54 and
         # thus not have a denominator, if the transfer function is
@@ -540,7 +569,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if self.cf_transfer_function_type == "DIGITAL":
             if len(self.denominator) == 0:
                 resp = scipy.signal.freqz(b=self.numerator,
-                                          a=[1.], worN=frequencies)[1]
+                                          a=[1.], worN=resp_frequencies)[1]
 
                 gain_freq_amp = np.abs(scipy.signal.freqz(
                     b=self.numerator, a=[1.],
@@ -551,7 +580,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                w = frequencies  # rename to be concise and match conventions
+                w = resp_frequencies  # rename to be concise and match conventions
 
                 resp = np.zeros_like(w) + 0j
                 for idx, num in enumerate(self.numerator):
@@ -569,14 +598,15 @@ class CoefficientsTypeResponseStage(ResponseStage):
         elif self.cf_transfer_function_type == "ANALOG (RADIANS/SECOND)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=frequencies / (np.pi * 2.0))[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies\
+                    / (np.pi * 2.0))[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency / (np.pi * 2.0)])[1])
         elif self.cf_transfer_function_type == "ANALOG (HERTZ)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=frequencies)[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies)[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency])[1])
@@ -598,7 +628,17 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # evalresp does this and thus so do we.
         if self.cf_transfer_function_type != 'DIGITAL':
             amp *= self.stage_gain / gain_freq_amp
-        final_resp = np.empty_like(resp)
+        
+        # If "fast", then interpolate the amplitude and phase onto the
+        # originally requested frequencies.
+        if len(frequencies) > 10000 and fast:
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=2)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
+        else:
+            final_resp = np.empty_like(resp)
         final_resp.real = amp * np.cos(phase)
         final_resp.imag = amp * np.sin(phase)
 
@@ -782,9 +822,23 @@ class FIRResponseStage(ResponseStage):
             coefficients = self._coefficients
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
-        resp = scipy.signal.freqz(b=coefficients, a=[1.], worN=frequencies)[1]
-        # Here we zero the phase (FIR) and return the amplitude
-        amp = np.abs(resp) * self.stage_gain + 0j
+        # Compute response for a limited number of frequencies and interpolate
+        # inbetween - 10000 appears fine for high precision and speed.
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+            resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                      worN=resp_frequencies)[1]
+            amp = np.abs(resp) * self.stage_gain + 0j
+            amp = amp.real
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+        else:
+            resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                      worN=frequencies)[1]
+            # Here we zero the phase (FIR) and return the amplitude
+            amp = np.abs(resp) * self.stage_gain + 0j
+            amp = amp.real
         return amp
 
 
@@ -1040,7 +1094,7 @@ class Response(ComparingObject):
         return response, freqs
 
     def get_response(self, frequencies, output="velocity", start_stage=None,
-                     end_stage=None):
+                     end_stage=None, fast=True):
         """
         Returns the frequency response for given frequencies.
         :type frequencies: list of float
@@ -1737,9 +1791,9 @@ class Response(ComparingObject):
                                             max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, amp, k=3)(frequencies)
+                    f, amp, k=2)(frequencies)
                 phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, phase, k=3)(frequencies)
+                    f, phase, k=2)(frequencies)
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -21,7 +21,7 @@ from matplotlib import rcParams
 
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
-    _pitick2latex,
+    _pitick2latex, Response,
     PolesZerosResponseStage, PolynomialResponseStage)
 from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2881,7 +2881,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # optionally prefilter in frequency domain and/or apply water level
         freq_response, freqs = \
             response.get_response_for_window_size(self.stats.delta, nfft,
-                                                  output=output, **kwargs)
+                                                  output=output, fast=fast,
+                                                  **kwargs)
 
         if plot:
             ax1.loglog(freqs, np.abs(data), color=color1, zorder=9)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2642,7 +2642,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
     @_add_processing_info
     def remove_response(self, inventory=None, output="VEL", water_level=60,
-                        pre_filt=None, zero_mean=True, taper=True,
+                        pre_filt=None, zero_mean=True, fast=True, taper=True,
                         taper_fraction=0.05, plot=False, fig=None, **kwargs):
         """
         Deconvolve instrument response.
@@ -2749,6 +2749,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type zero_mean: bool
         :param zero_mean: If `True`, the mean of the waveform data is
             subtracted in time domain prior to deconvolution.
+        :type fast: bool
+        :param fast: When set to True (default), then the calculation of the
+            response for a large number of frequencies is sped up through
+            interpolation. Relevant for traces with >10000 samples.
         :type taper: bool
         :param taper: If `True`, a cosine taper is applied to the waveform data
             in time domain prior to deconvolution.


### PR DESCRIPTION
### What does this PR do?
Speed up `remove_response` for longer traces by using interpolation in the calculation of the frequency-responses. With the `fast=True`-option, the response-removal for one trace with 24 hours of data, sampled at 100 Hz, happens in 10 s instead of ~5 minutes on my machine.


### Why was it initiated?  
With this PR I would like to share my changes to speed up the response-removal. I see that merging all the `evalresp`-changes into obspy is a big task and it is in progress, so I understand if can understand if you'd rather wait with merging extra changes. 

As I cannot create this PR in the main obspy-repository before the `evalresp`-changes are merged, It seemed useful  to have a clean PR toward the original rewrite of the `evalresp`-functionality for others to be able to check and comment. But once the `evalresp`-changes are merged into the main obspy-repository, I can of course move this PR there as well.

### Any relevant Issues?
I first described the problem of slow response-calculation in this issue in the main obspy-repository: https://github.com/obspy/obspy/issues/2621.

Right now, not all tests in `obspy/core/tests/test_response.py` succeed, but this appeared to be the case before the changes in this PR. I have done several comparisons of the response-removal with and without interpolation, but, of course, I'll need to add more tests that `fast=False` and `fast=True` are really producing the same results within the defined tolerance.

When `fast=True` is chosen, what then becomes computationally most expensive is the interpolation itself. So I may need to do more tests to check for which types of responses the `get_response`-functions should rather be called with or without interpolation as a default.

### PR Checklist
- [X] This PR is not directly related to an existing issue (which has no PR yet). 
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
