### PR TITLE
Interpolation: change call-argument and logspace

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,10 @@ Changes:
  - fix an installation issue with pip and setuptools version 46 (see #2578)
  - fix response plots when providing `axes=...` with a numpy array of Axes
    instances (see #2579)
+ - add methods for calculating responses outside of evalresp -- these methods
+   are part of the Response class and called get_response (which matches the
+   signature of get_evalresp_response_for_frequencies) and
+   get_response_for_window_size (which matches get_evalresp_response).
 
 1.2.0 (doi: 10.5281/zenodo.3674646)
 ===================================

--- a/obspy/core/inventory/__init__.py
+++ b/obspy/core/inventory/__init__.py
@@ -177,11 +177,11 @@ For more examples see the :ref:`Obspy Gallery <gallery>`.
 
 Dealing with the Response information
 -------------------------------------
-The :meth:`~obspy.core.inventory.response.Response.get_evalresp_response`
-method will call some functions within evalresp to generate the response.
+The :meth:`~obspy.core.inventory.response.Response.get_response_for_window_size`
+method will generate the response based on frequency delta and window size (nfft).
 
 >>> response = cha.response
->>> response, freqs = response.get_evalresp_response(0.1, 16384, output="VEL")
+>>> response, freqs = response.get_response_for_window_size(0.1, 16384, output="VEL")
 >>> print(response)  # doctest: +NORMALIZE_WHITESPACE
  [  0.00000000e+00 +0.00000000e+00j  -1.36383361e+07 +1.42086194e+06j
    -5.36470300e+07 +1.13620679e+07j ...,   2.48907496e+09 -3.94151237e+08j

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -177,7 +177,13 @@ class ResponseStage(ComparingObject):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
+        """
+        :param frequencies: Frequency range to get resp curve over
+        :param fast: Dummy argument to make function similar to
+                     get_response-functions for other stage-types.
+        :return: The curve describing this response stage
+        """
         # if a response stage isn't a subclass then it's likely a gain stage.
         return np.ones_like(frequencies) * self.stage_gain
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1070,7 +1070,8 @@ class Response(ComparingObject):
             raise ValueError("Unknown unit '%s'." % unit)
 
     def get_response_for_window_size(self, t_samp, nfft, output="VEL",
-                                     start_stage=None, end_stage=None):
+                                     start_stage=None, end_stage=None,
+                                     fast=True):
         """
         Returns frequency response and corresponding frequencies for
         the given sample rate delta and FFT window size
@@ -1108,7 +1109,8 @@ class Response(ComparingObject):
             freqs = np.linspace(0, fy, int(nfft // 2) + 1).astype(np.float64)
 
         response = self.get_response(
-            freqs, output=output, start_stage=start_stage, end_stage=end_stage)
+            freqs, output=output, start_stage=start_stage, end_stage=end_stage,
+            fast=fast)
         return response, freqs
 
     def get_response(self, frequencies, output="velocity", start_stage=None,

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -346,11 +346,11 @@ class PolesZerosResponseStage(ResponseStage):
         Produce the response curve from this stage's data for a given
         range of frequencies
         :param frequencies: Frequency range to get resp curve over
-        :param n_frequencies_limit_for_interp: Indicates a limit for the number
-            of frequencies (=number of samples in a trace) for which the
-            response curve is calculated. Above this number of frequencies, the
-            response curve is interpolated. Speeds up response-calculation for
-            traces with many samples, e.g., >10000.
+        :param n_frequencies_limit_for_interp:
+            Indicates a limit for the number of frequencies (=number of samples
+            in a trace) for which the response curve is calculated. Above this
+            number of frequencies, the response curve is interpolated. Speeds
+            up response-calculation for traces with many samples, e.g., >10000.
         :return: The curve describing this response stage
         """
         # Has to be imported here for now to avoid circular imports.
@@ -566,11 +566,11 @@ class CoefficientsTypeResponseStage(ResponseStage):
         Produce the response curve from this coefficient
         response stage for a range of frequencies
         :param frequencies: Frequency range to get resp curve over
-        :param n_frequencies_limit_for_interp: Indicates a limit for the number
-            of frequencies (=number of samples in a trace) for which the
-            response curve is calculated. Above this number of frequencies, the
-            response curve is interpolated. Speeds up response-calculation for
-            traces with many samples, e.g., >10000.
+        :param n_frequencies_limit_for_interp:
+            Indicates a limit for the number of frequencies (=number of samples
+            in a trace) for which the response curve is calculated. Above this
+            number of frequencies, the response curve is interpolated. Speeds
+            up response-calculation for traces with many samples, e.g., >10000.
         :return: The curve describing this response stage
         """
         # Decimation blockette, e.g. gain only!
@@ -845,11 +845,11 @@ class FIRResponseStage(ResponseStage):
         """
         Given Computes the
         :param frequencies: Discrete frequencies to calculate response for.
-        :param n_frequencies_limit_for_interp: Indicates a limit for the number
-            of frequencies (=number of samples in a trace) for which the
-            response curve is calculated. Above this number of frequencies, the
-            response curve is interpolated. Speeds up response-calculation for
-            traces with many samples, e.g., >10000.
+        :param n_frequencies_limit_for_interp:
+            Indicates a limit for the number of frequencies (=number of samples
+            in a trace) for which the response curve is calculated. Above this
+            number of frequencies, the response curve is interpolated. Speeds
+            up response-calculation for traces with many samples, e.g., >10000.
         """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
@@ -1126,6 +1126,12 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
+        :type n_frequencies_limit_for_interp: int
+        :param n_frequencies_limit_for_interp:
+            Indicates a limit for the number of frequencies (=number of samples
+            in a trace) for which the response curve is calculated. Above this
+            number of frequencies, the response curve is interpolated. Speeds
+            up response-calculation for traces with many samples, e.g., >10000.
         :rtype: tuple of two arrays
         :returns: frequency response and corresponding frequencies
         """
@@ -1164,11 +1170,11 @@ class Response(ComparingObject):
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
         :type n_frequencies_limit_for_interp: int
-        :param n_frequencies_limit_for_interp: Indicates a limit for the number
-            of frequencies (=number of samples in a trace) for which the
-            response curve is calculated. Above this number of frequencies, the
-            response curve is interpolated. Speeds up response-calculation for
-            traces with many samples, e.g., >10000.
+        :param n_frequencies_limit_for_interp:
+            Indicates a limit for the number of frequencies (=number of samples
+            in a trace) for which the response curve is calculated. Above this
+            number of frequencies, the response curve is interpolated. Speeds
+            up response-calculation for traces with many samples, e.g., >10000.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -351,25 +351,23 @@ class PolesZerosResponseStage(ResponseStage):
             response curve is calculated. Above this number of frequencies, the
             response curve is interpolated. Speeds up response-calculation for
             traces with many samples, e.g., >10000.
-        Indicates whether to speed up calculation through
-            interpolation.
         :return: The curve describing this response stage
         """
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
-        
+
         interpolate = False
         if n_frequencies_limit_for_interp is None:
             if len(frequencies) > n_frequencies_limit_for_interp:
                 interpolate = True
-                
+
         if interpolate:
             resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
                                             n_frequencies_limit_for_interp,
                                             dtype=np.float64)
         else:
             resp_frequencies = frequencies
-            
+
 
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
@@ -587,7 +585,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if n_frequencies_limit_for_interp is None:
             if len(frequencies) > n_frequencies_limit_for_interp:
                 interpolate = True
-                
+
         if interpolate:
             resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
                                             n_frequencies_limit_for_interp,
@@ -872,13 +870,13 @@ class FIRResponseStage(ResponseStage):
         if n_frequencies_limit_for_interp is not None:
             if len(frequencies) > n_frequencies_limit_for_interp:
                 interpolate = True
-                
+
         if interpolate:
             resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
                                             n_frequencies_limit_for_interp,
                                             dtype=np.float64)
             resp = scipy.signal.freqz(b=coefficients, a=[1.],
-                                        worN=resp_frequencies)[1]
+                                      worN=resp_frequencies)[1]
             amp = np.abs(resp) * self.stage_gain + 0j
             amp = amp.real
             amp = scipy.interpolate.InterpolatedUnivariateSpline(

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -31,7 +31,7 @@ from obspy.core.util.obspy_types import (ComplexWithUncertainties,
                                          Enum)
 
 from .util import Angle, Frequency
-
+from obspy.signal.invsim import digital_filter_to_freq_resp
 
 class ResponseStage(ComparingObject):
     """

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -357,13 +357,19 @@ class PolesZerosResponseStage(ResponseStage):
         """
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
-        if n_frequencies_limit_for_interp is not None:
+        
+        interpolate = False
+        if n_frequencies_limit_for_interp is None:
             if len(frequencies) > n_frequencies_limit_for_interp:
-                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                               n_frequencies_limit_for_interp,
-                                               dtype=np.float64)
+                interpolate = True
+                
+        if interpolate:
+            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                            n_frequencies_limit_for_interp,
+                                            dtype=np.float64)
         else:
             resp_frequencies = frequencies
+            
 
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
@@ -372,17 +378,16 @@ class PolesZerosResponseStage(ResponseStage):
             frequencies=resp_frequencies, freq=False) * self.stage_gain
 
         # If required, do interpolation of amplitude and phase of the response
-        if n_frequencies_limit_for_interp is not None:
-            if len(frequencies) > n_frequencies_limit_for_interp:
-                amp = np.abs(resp)
-                phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
-                amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=3)(frequencies)
-                phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, phase, k=3)(frequencies)
-                final_resp = np.zeros_like(frequencies) + 0j
-                final_resp.real = amp * np.cos(phase)
-                final_resp.imag = amp * np.sin(phase)
+        if interpolate:
+            amp = np.abs(resp)
+            phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                resp_frequencies, amp, k=3)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                resp_frequencies, phase, k=3)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
+            final_resp.real = amp * np.cos(phase)
+            final_resp.imag = amp * np.sin(phase)
         else:
             final_resp = resp
 
@@ -578,11 +583,15 @@ class CoefficientsTypeResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
 
         # Check if interpolation is required so save time for long traces.
-        if n_frequencies_limit_for_interp is not None:
+        interpolate = False
+        if n_frequencies_limit_for_interp is None:
             if len(frequencies) > n_frequencies_limit_for_interp:
-                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                               n_frequencies_limit_for_interp,
-                                               dtype=np.float64)
+                interpolate = True
+                
+        if interpolate:
+            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                            n_frequencies_limit_for_interp,
+                                            dtype=np.float64)
         else:
             resp_frequencies = frequencies
 
@@ -657,13 +666,12 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # If an interpolation limit (n_frequencies_limit_for_interp) is set,
         # then interpolate the amplitude and phase onto the originally
         # requested frequencies.
-        if n_frequencies_limit_for_interp is not None:
-            if len(frequencies) > n_frequencies_limit_for_interp:
-                amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                        resp_frequencies, amp, k=3)(frequencies)
-                phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                        resp_frequencies, phase, k=3)(frequencies)
-                final_resp = np.zeros_like(frequencies) + 0j
+        if interpolate:
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=3)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=3)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
         else:
             final_resp = np.empty_like(resp)
         final_resp.real = amp * np.cos(phase)
@@ -860,17 +868,21 @@ class FIRResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
         # Compute response for a limited number of frequencies and interpolate
         # inbetween - 10000 appears fine for high precision and speed.
+        interpolate = False
         if n_frequencies_limit_for_interp is not None:
             if len(frequencies) > n_frequencies_limit_for_interp:
-                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                               n_frequencies_limit_for_interp,
-                                               dtype=np.float64)
-                resp = scipy.signal.freqz(b=coefficients, a=[1.],
-                                          worN=resp_frequencies)[1]
-                amp = np.abs(resp) * self.stage_gain + 0j
-                amp = amp.real
-                amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                        resp_frequencies, amp, k=3)(frequencies)
+                interpolate = True
+                
+        if interpolate:
+            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                            n_frequencies_limit_for_interp,
+                                            dtype=np.float64)
+            resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                        worN=resp_frequencies)[1]
+            amp = np.abs(resp) * self.stage_gain + 0j
+            amp = amp.real
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=3)(frequencies)
         else:
             resp = scipy.signal.freqz(b=coefficients, a=[1.],
                                       worN=frequencies)[1]

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -178,8 +178,9 @@ class ResponseStage(ComparingObject):
 
     def get_response(self, frequencies):
         # if a response stage isn't a subclass then it's likely a gain stage.
-        # in that case just return an array of the constant gain
-        return np.ones_like(frequencies) * self.stage_gain
+        # just return a constant 1; the response is scaled so trying to
+        # apply the gain here will cause to be factored out later
+        return 1.
 
 
 class PolesZerosResponseStage(ResponseStage):
@@ -576,7 +577,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # frequency. I'm not sure this is entirely correct, as the digitizer
         # will likely just apply the FIR filter and send the data along. But
         # evalresp does this and thus so do we.
-        amp *= self.stage_gain / gain_freq_amp
+        if self.cf_transfer_function_type != 'DIGITAL':
+            amp *= self.stage_gain / gain_freq_amp
         final_resp = np.empty_like(resp)
         final_resp.real = amp * np.cos(phase)
         final_resp.imag = amp * np.sin(phase)

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -570,7 +570,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         # Check if interpolation is required so save time for long traces.
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp, 'log')
+            frequencies, n_frequencies_limit_for_interp)
 
         # While most cases we expect this to represent a Bkt. 54 and
         # thus not have a denominator, if the transfer function is

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -340,6 +340,8 @@ class PolesZerosResponseStage(ResponseStage):
         Produce the response curve from this stage's data for a given
         range of frequencies
         :param frequencies: Frequency range to get resp curve over
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         :return: The curve describing this response stage
         """
         # Has to be imported here for now to avoid circular imports.
@@ -361,9 +363,9 @@ class PolesZerosResponseStage(ResponseStage):
             amp = np.abs(resp)
             phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
             amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=2)(frequencies)
+                resp_frequencies, amp, k=2)(frequencies)
             phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, phase, k=2)(frequencies)
+                resp_frequencies, phase, k=2)(frequencies)
             final_resp = np.zeros_like(frequencies) + 0j
             final_resp.real = amp * np.cos(phase)
             final_resp.imag = amp * np.sin(phase)
@@ -547,6 +549,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         Produce the response curve from this coefficient
         response stage for a range of frequencies
         :param frequencies: Frequency range to get resp curve over
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         :return: The curve describing this response stage
         """
         # Decimation blockette, e.g. gain only!
@@ -580,7 +584,9 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                w = resp_frequencies  # rename to be concise and match conventions
+                
+                # rename to be concise and match conventions
+                w = resp_frequencies
 
                 resp = np.zeros_like(w) + 0j
                 for idx, num in enumerate(self.numerator):
@@ -810,7 +816,10 @@ class FIRResponseStage(ResponseStage):
 
     def get_response(self, frequencies, fast=True):
         """
-        Given Computes the 
+        Given Computes the
+        :param frequencies: Discrete frequencies to calculate response for. 
+        :param fast: Indicates whether to speed up calculation through
+            interpolation.
         """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -351,13 +351,13 @@ class PolesZerosResponseStage(ResponseStage):
                                            10000, dtype=np.float64)
         else:
             resp_frequencies = frequencies
-            
+
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
             zeros=np.array(self._zeros, dtype=np.complex128),
             scale_fac=self.normalization_factor,
             frequencies=resp_frequencies, freq=False) * self.stage_gain
-        
+
         # If required, do interpolation of amplitude and phase of the response
         if len(frequencies) > 10000 and fast:
             amp = np.abs(resp)
@@ -371,7 +371,7 @@ class PolesZerosResponseStage(ResponseStage):
             final_resp.imag = amp * np.sin(phase)
         else:
             final_resp = resp
-        
+
         return final_resp
 
     def calc_normalization_factor(self):
@@ -559,7 +559,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
-        
+
         # Check if interpolation is required so save time for long traces.
         if len(frequencies) > 10000 and fast:
             resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
@@ -584,7 +584,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                
+
                 # rename to be concise and match conventions
                 w = resp_frequencies
 
@@ -604,8 +604,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         elif self.cf_transfer_function_type == "ANALOG (RADIANS/SECOND)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=resp_frequencies\
-                    / (np.pi * 2.0))[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies
+                / (np.pi * 2.0))[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency / (np.pi * 2.0)])[1])
@@ -634,7 +634,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # evalresp does this and thus so do we.
         if self.cf_transfer_function_type != 'DIGITAL':
             amp *= self.stage_gain / gain_freq_amp
-        
+
         # If "fast", then interpolate the amplitude and phase onto the
         # originally requested frequencies.
         if len(frequencies) > 10000 and fast:
@@ -817,7 +817,7 @@ class FIRResponseStage(ResponseStage):
     def get_response(self, frequencies, fast=True):
         """
         Given Computes the
-        :param frequencies: Discrete frequencies to calculate response for. 
+        :param frequencies: Discrete frequencies to calculate response for.
         :param fast: Indicates whether to speed up calculation through
             interpolation.
         """

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -362,7 +362,6 @@ class PolesZerosResponseStage(ResponseStage):
             return None
 
         A0 = 1.0 + (1j * 0.0)
-        # TODO: ensure that this coercion to float is valid
         if self.pz_transfer_function_type == "LAPLACE (HERTZ)":
             s = 1j * float(self.normalization_frequency)
         elif self.pz_transfer_function_type == "LAPLACE (RADIANS/SECOND)":
@@ -1003,8 +1002,8 @@ class Response(ComparingObject):
             stages = self.response_stages[slice(start_stage, end_stage)]
             ref = stages.pop(0).get_response(frequencies=f)
             for stage in stages[1:]:
-                if 'get_response' in dir(stage):
-                    ref *= stage.get_response(frequencies=f)
+                # TODO: fix AttributeError in some stages
+                ref *= stage.get_response(frequencies=f)
             resp *= self.instrument_sensitivity.value / np.abs(ref[0])
 
         # By now the response is in the input units of the first stage.

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -32,6 +32,7 @@ from obspy.core.util.obspy_types import (ComplexWithUncertainties,
 
 from .util import Angle, Frequency
 
+
 class ResponseStage(ComparingObject):
     """
     From the StationXML Definition:
@@ -128,15 +129,15 @@ class ResponseStage(ComparingObject):
         self.description = description
         self.decimation_input_sample_rate = \
             Frequency(decimation_input_sample_rate) \
-                if decimation_input_sample_rate is not None else None
+            if decimation_input_sample_rate is not None else None
         self.decimation_factor = decimation_factor
         self.decimation_offset = decimation_offset
         self.decimation_delay = \
             FloatWithUncertaintiesAndUnit(decimation_delay) \
-                if decimation_delay is not None else None
+            if decimation_delay is not None else None
         self.decimation_correction = \
             FloatWithUncertaintiesAndUnit(decimation_correction) \
-                if decimation_correction is not None else None
+            if decimation_correction is not None else None
 
     def __str__(self):
         ret = (
@@ -215,8 +216,8 @@ class PolesZerosResponseStage(ResponseStage):
                  stage_gain_frequency, input_units, output_units,
                  pz_transfer_function_type,
                  normalization_frequency, zeros, poles,
-                 normalization_factor=None, resource_id=None, resource_id2=None,
-                 name=None, input_units_description=None,
+                 normalization_factor=None, resource_id=None,
+                 resource_id2=None, name=None, input_units_description=None,
                  output_units_description=None, description=None,
                  decimation_input_sample_rate=None, decimation_factor=None,
                  decimation_offset=None, decimation_delay=None,
@@ -233,7 +234,8 @@ class PolesZerosResponseStage(ResponseStage):
             if not isinstance(x, ComplexWithUncertainties):
                 poles[i] = ComplexWithUncertainties(x)
         self._poles = poles
-        # if we don't have a normalization factor, calculate it (needs P/Z set first)
+        # if we don't have a normalization factor
+        # calculate it (needs P/Z set first)
         if normalization_factor is None:
             normalization_factor = self.calc_normalization_factor()
         self.normalization_factor = float(normalization_factor)
@@ -520,8 +522,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
     def get_response(self, frequencies):
         """
-        Produce the response curve from this coefficient response stage for a range
-        of frequencies
+        Produce the response curve from this coefficient
+        response stage for a range of frequencies
         :param frequencies: Frequency range to get resp curve over
         :return: The curve describing this response stage
         """
@@ -537,16 +539,19 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # digital, this may not be the case
         if self.cf_transfer_function_type == "DIGITAL":
             if len(self.denominator) == 0:
-                resp = scipy.signal.freqz(b=self.numerator, a=[1.], worN=frequencies)[1]
+                resp = scipy.signal.freqz(b=self.numerator,
+                                          a=[1.], worN=frequencies)[1]
 
                 gain_freq_amp = np.abs(scipy.signal.freqz(
-                    b=self.numerator, a=[1.], worN=[self.stage_gain_frequency])[1])
+                    b=self.numerator, a=[1.],
+                    worN=[self.stage_gain_frequency])[1])
             else:
-                # evalresp handles this a bit oddly, and we can't just use freqs
-                # or freqz to calculate our terms here. we get the numerator and
-                # denominator and do the math on them in their representation
-                # as magnitude and phase rather than standard complex format
-                w = frequencies  # rename to be concise and match the math conventions
+                # evalresp handles this a bit oddly, and we can't just
+                # use freqs or freqz to calculate our terms here.
+                # we get the numerator and denominator and do the math
+                # on them in their representation as magnitude and
+                # phase rather than standard complex format
+                w = frequencies  # rename to be concise and match conventions
 
                 resp = np.zeros_like(w) + 0j
                 for idx, num in enumerate(self.numerator):
@@ -764,10 +769,10 @@ class FIRResponseStage(ResponseStage):
         self._coefficients = new_values
 
     def get_response(self, frequencies):
-        from obspy.signal.invsim import digital_filter_to_freq_resp
-        sr = self.decimation_input_sample_rate
-        frequencies = frequencies / sr * np.pi * 2.0
-
+        # Decimation blockette, e.g. gain only!
+        if not len(self._coefficients):
+            return np.ones_like(frequencies) * self.stage_gain
+        # We need to correct the coefficients for the different cases
         if self.symmetry == 'ODD':
             coefficients = self._coefficients + self._coefficients[::-1][1:]
         elif self.symmetry == 'EVEN':
@@ -775,8 +780,12 @@ class FIRResponseStage(ResponseStage):
         else:
             # This is the full case
             coefficients = self._coefficients
-        return digital_filter_to_freq_resp([1.], coefficients,
-                                           frequencies=frequencies) * self.stage_gain
+        sr = self.decimation_input_sample_rate
+        frequencies = frequencies / sr * np.pi * 2.0
+        resp = scipy.signal.freqz(b=coefficients, a=[1.], worN=frequencies)[1]
+        # Here we zero the phase (FIR) and return the amplitude
+        amp = np.abs(resp) * self.stage_gain + 0j
+        return amp
 
 
 class PolynomialResponseStage(ResponseStage):
@@ -1060,7 +1069,6 @@ class Response(ComparingObject):
         else:
             raise ValueError("Unknown output '%s'." % output)
 
-        apply_sens = True
         # Convert to 0-based indexing.
         # (End stage stays the same because it's the exclusive bound)
         if start_stage is None:
@@ -1249,7 +1257,7 @@ class Response(ComparingObject):
 
         # Nothing might be set - just return in that case.
         if set(itertools.chain.from_iterable(v.values()
-                                             for v in sampling_rates.values())) == {None}:
+               for v in sampling_rates.values())) == {None}:
             return sampling_rates
 
         # Find the first set input sampling rate. The output sampling rate
@@ -1793,11 +1801,11 @@ class Response(ComparingObject):
             if isinstance(blockette, PolesZerosResponseStage) and \
                     blockette.stage_gain and \
                     None in set([
-                blockette.decimation_correction,
-                blockette.decimation_delay,
-                blockette.decimation_factor,
-                blockette.decimation_input_sample_rate,
-                blockette.decimation_offset]):
+                                blockette.decimation_correction,
+                                blockette.decimation_delay,
+                                blockette.decimation_factor,
+                                blockette.decimation_input_sample_rate,
+                                blockette.decimation_offset]):
                 # Don't modify the original object.
                 blockette = copy.deepcopy(blockette)
                 blockette.decimation_correction = 0.0

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -909,7 +909,8 @@ class Response(ComparingObject):
     """
     # The various types of units.
     core_unit_enum = Enum(["displacement", "velocity", "acceleration",
-                           "volts", "counts", "tesla", "pressure"])
+                           "volts", "counts", "tesla", "pressure",
+                           "temperature"])
 
     def __init__(self, resource_id=None, instrument_sensitivity=None,
                  instrument_polynomial=None, response_stages=None):
@@ -991,6 +992,8 @@ class Response(ComparingObject):
             return self.core_unit_enum.tesla
         elif unit in ("PA", "MBAR"):
             return self.core_unit_enum.pressure
+        elif unit in ("CELSIUS",):
+            return self.core_unit_enum.temperature
         else:
             raise ValueError("Unknown unit '%s'." % unit)
 
@@ -1099,9 +1102,14 @@ class Response(ComparingObject):
 
         # By now the response is in the input units of the first stage.
         diff_and_int_map = {
+            # Displacement -> velocity - acceleration.
             self.core_unit_enum.displacement: 0,
             self.core_unit_enum.velocity: 1,
-            self.core_unit_enum.acceleration: 2}
+            self.core_unit_enum.acceleration: 2,
+            # XXX: Kind of strange but evalresp does the same for these.
+            self.core_unit_enum.volts: 1,
+            self.core_unit_enum.temperature: 0,
+            }
         unit_type = self._get_unit_type(self.response_stages[0].input_units)
         if unit_type not in diff_and_int_map:
             raise ValueError("Cannot convert %s to %s." % (unit_type, output))

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -367,10 +367,8 @@ class PolesZerosResponseStage(ResponseStage):
         if interpolate:
             amp = np.abs(resp)
             phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                resp_frequencies, amp, k=3)(frequencies)
-            phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                resp_frequencies, phase, k=3)(frequencies)
+            amp = _interpolate(resp_frequencies, amp, frequencies)
+            phase = _interpolate(resp_frequencies, phase, frequencies)
             final_resp = np.zeros_like(frequencies) + 0j
             final_resp.real = amp * np.cos(phase)
             final_resp.imag = amp * np.sin(phase)
@@ -569,13 +567,6 @@ class CoefficientsTypeResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
 
         # Check if interpolation is required so save time for long traces.
-        if len(frequencies) > 10000 and fast:
-            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
-                                           10000, dtype=np.float64)
-        else:
-            resp_frequencies = frequencies
-
-        # Check if interpolation is required so save time for long traces.
         interpolate, resp_frequencies = _check_response_interpolation(
             frequencies, n_frequencies_limit_for_interp)
 
@@ -651,10 +642,8 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # then interpolate the amplitude and phase onto the originally
         # requested frequencies.
         if interpolate:
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=3)(frequencies)
-            phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, phase, k=3)(frequencies)
+            amp = _interpolate(resp_frequencies, amp, frequencies)
+            phase = _interpolate(resp_frequencies, phase, frequencies)
             final_resp = np.zeros_like(frequencies) + 0j
         else:
             final_resp = np.empty_like(resp)
@@ -862,8 +851,7 @@ class FIRResponseStage(ResponseStage):
         amp = amp.real
 
         if interpolate:
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                resp_frequencies, amp, k=3)(frequencies)
+            amp = _interpolate(resp_frequencies, amp, frequencies)
 
         return amp
 
@@ -1838,10 +1826,8 @@ class Response(ComparingObject):
                     raise ValueError(msg % (min_f_avail, max_f_avail, min_f,
                                             max_f))
 
-                amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, amp, k=3)(frequencies)
-                phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, phase, k=3)(frequencies)
+                amp = _interpolate(f, amp, frequencies)
+                phase = _interpolate(f, phase, frequencies)
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0
@@ -2733,6 +2719,7 @@ def _pitick2latex(x):
         string += r"\frac{%s\pi}{2}$" % x
     return string
 
+
 def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
     """
     Helper function to check whether the calculation of the response for a set
@@ -2751,7 +2738,7 @@ def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
         input are the same that are output).
     """
     interpolate = False
-    if n_frequencies_limit_for_interp is None:
+    if n_frequencies_limit_for_interp is not None:
         if len(frequencies) > n_frequencies_limit_for_interp:
             interpolate = True
 
@@ -2763,6 +2750,20 @@ def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
         resp_frequencies = frequencies
 
     return interpolate, resp_frequencies
+
+
+def _interpolate(resp_frequencies, y, frequencies):
+    """
+    Helper-function for the cubic interpolation of phase or amplitude from the
+    reduced set of frequencies to the full set of frequencies.
+    :param resp_frequencies: reduced set of frequencies
+    :param frequencies: full set of frequencies
+    :rtype: numpy.array
+    :returns: interpolated values of x
+    """
+    y_interp = scipy.interpolate.InterpolatedUnivariateSpline(
+        resp_frequencies, y, k=3)(frequencies)
+    return y_interp
 
 
 if __name__ == '__main__':

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1116,6 +1116,10 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
+        :type fast: bool
+        :param fast: When set to True (default), then the calculation of the
+            response for a large number of frequencies is sped up through
+            interpolation. Relevant for traces with >10000 samples.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """
@@ -1140,10 +1144,10 @@ class Response(ComparingObject):
         stages = self.response_stages[slice(start_stage, end_stage)]
         # map 0j here to ensure the curve is complex values
         # which it may not be if we start on a gain stage
-        resp = stages[0].get_response(frequencies=frequencies) + 0j
+        resp = stages[0].get_response(frequencies=frequencies, fast=fast) + 0j
         for stage in stages[1:]:
             try:
-                resp *= stage.get_response(frequencies=frequencies)
+                resp *= stage.get_response(frequencies=frequencies, fast=fast)
             except AttributeError:
                 raise NotImplementedError
 
@@ -1152,9 +1156,9 @@ class Response(ComparingObject):
         if start_stage == 0 and end_stage is None:
             f = np.array([self.instrument_sensitivity.frequency])
             stages = self.response_stages[slice(start_stage, end_stage)]
-            ref = stages[0].get_response(frequencies=f)
+            ref = stages[0].get_response(frequencies=f, fast=fast)
             for stage in stages[1:]:
-                ref *= stage.get_response(frequencies=f)
+                ref *= stage.get_response(frequencies=f, fast=fast)
             resp *= self.instrument_sensitivity.value / np.abs(ref[0])
 
         # By now the response is in the input units of the first stage.

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -355,7 +355,7 @@ class PolesZerosResponseStage(ResponseStage):
         from obspy.signal.invsim import paz_to_freq_resp
 
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp, space='log')
+            frequencies, n_frequencies_limit_for_interp)
 
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
@@ -832,8 +832,6 @@ class FIRResponseStage(ResponseStage):
             number of frequencies, the response curve is interpolated. Speeds
             up response-calculation for traces with many samples, e.g., >10000.
         """
-        # seems ok with linear spaced values
-
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
             return np.ones_like(frequencies) * self.stage_gain
@@ -850,7 +848,7 @@ class FIRResponseStage(ResponseStage):
         # Compute response for a limited number of frequencies and interpolate
         # inbetween - 10000 appears fine for high precision and speed.
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp, 'lin')
+            frequencies, n_frequencies_limit_for_interp)
 
         resp = scipy.signal.freqz(b=coefficients, a=[1.],
                                   worN=resp_frequencies)[1]
@@ -2728,8 +2726,7 @@ def _pitick2latex(x):
     return string
 
 
-def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp,
-                                  space='lin'):
+def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
     """
     Helper function to check whether the calculation of the response for a set
     of frequencies shall use interpolation or not.
@@ -2752,24 +2749,19 @@ def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp,
             interpolate = True
 
     if interpolate:
-        if space.lower() == 'lin':
-            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
-                                           n_frequencies_limit_for_interp,
-                                           dtype=np.float64)
-        elif space.lower() == 'log':
-            # If the first frequency is zero, then we need to add the zero after
-            # the logspace has been created.
-            if frequencies[0] == 0:
-                resp_frequencies = np.logspace(np.log10(frequencies[1]),
-                                            np.log10(frequencies[-1]),
-                                            n_frequencies_limit_for_interp-1,
-                                            dtype=np.float64)
-                resp_frequencies = np.concatenate((np.zeros(1), resp_frequencies))
-            else:
-                resp_frequencies = np.logspace(np.log10(frequencies[1]),
-                                            np.log10(frequencies[-1]),
-                                            n_frequencies_limit_for_interp,
-                                            dtype=np.float64)
+        # If the first frequency is zero, then we need to add the zero after
+        # the logspace has been created.
+        if frequencies[0] == 0:
+            resp_frequencies = np.logspace(np.log10(frequencies[1]),
+                                        np.log10(frequencies[-1]),
+                                        n_frequencies_limit_for_interp-1,
+                                        dtype=np.float64)
+            resp_frequencies = np.concatenate((np.zeros(1), resp_frequencies))
+        else:
+            resp_frequencies = np.logspace(np.log10(frequencies[1]),
+                                        np.log10(frequencies[-1]),
+                                        n_frequencies_limit_for_interp,
+                                        dtype=np.float64)
     else:
         resp_frequencies = frequencies
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -177,11 +177,9 @@ class ResponseStage(ComparingObject):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
 
-    def get_response(self, frequencies, n_frequencies_limit_for_interp=None):
+    def get_response(self, frequencies, **kwargs):
         """
         :param frequencies: Frequency range to get resp curve over
-        :param n_frequencies_limit_for_interp: Dummy argument to make function
-            similar to get_response-functions for other stage-types.
         :return: The curve describing this response stage
         """
         # if a response stage isn't a subclass then it's likely a gain stage.
@@ -356,18 +354,8 @@ class PolesZerosResponseStage(ResponseStage):
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
 
-        interpolate = False
-        if n_frequencies_limit_for_interp is None:
-            if len(frequencies) > n_frequencies_limit_for_interp:
-                interpolate = True
-
-        if interpolate:
-            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                            n_frequencies_limit_for_interp,
-                                            dtype=np.float64)
-        else:
-            resp_frequencies = frequencies
-
+        interpolate, resp_frequencies = _check_response_interpolation(
+            frequencies, n_frequencies_limit_for_interp)
 
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
@@ -581,17 +569,15 @@ class CoefficientsTypeResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
 
         # Check if interpolation is required so save time for long traces.
-        interpolate = False
-        if n_frequencies_limit_for_interp is None:
-            if len(frequencies) > n_frequencies_limit_for_interp:
-                interpolate = True
-
-        if interpolate:
-            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                            n_frequencies_limit_for_interp,
-                                            dtype=np.float64)
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
         else:
             resp_frequencies = frequencies
+
+        # Check if interpolation is required so save time for long traces.
+        interpolate, resp_frequencies = _check_response_interpolation(
+            frequencies, n_frequencies_limit_for_interp)
 
         # While most cases we expect this to represent a Bkt. 54 and
         # thus not have a denominator, if the transfer function is
@@ -866,27 +852,19 @@ class FIRResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
         # Compute response for a limited number of frequencies and interpolate
         # inbetween - 10000 appears fine for high precision and speed.
-        interpolate = False
-        if n_frequencies_limit_for_interp is not None:
-            if len(frequencies) > n_frequencies_limit_for_interp:
-                interpolate = True
+        interpolate, resp_frequencies = _check_response_interpolation(
+            frequencies, n_frequencies_limit_for_interp)
+
+        resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                  worN=resp_frequencies)[1]
+        # Here we zero the phase (FIR) and return the amplitude
+        amp = np.abs(resp) * self.stage_gain + 0j
+        amp = amp.real
 
         if interpolate:
-            resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                            n_frequencies_limit_for_interp,
-                                            dtype=np.float64)
-            resp = scipy.signal.freqz(b=coefficients, a=[1.],
-                                      worN=resp_frequencies)[1]
-            amp = np.abs(resp) * self.stage_gain + 0j
-            amp = amp.real
             amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=3)(frequencies)
-        else:
-            resp = scipy.signal.freqz(b=coefficients, a=[1.],
-                                      worN=frequencies)[1]
-            # Here we zero the phase (FIR) and return the amplitude
-            amp = np.abs(resp) * self.stage_gain + 0j
-            amp = amp.real
+                resp_frequencies, amp, k=3)(frequencies)
+
         return amp
 
 
@@ -2754,6 +2732,37 @@ def _pitick2latex(x):
             x = ""
         string += r"\frac{%s\pi}{2}$" % x
     return string
+
+def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
+    """
+    Helper function to check whether the calculation of the response for a set
+    of frequencies shall use interpolation or not.
+
+    :type n_frequencies_limit_for_interp: int
+    :param n_frequencies_limit_for_interp:
+        Indicates a limit for the number of frequencies (=number of samples
+        in a trace) for which the response curve is calculated. Above this
+        number of frequencies, the response curve is interpolated. Speeds
+        up response-calculation for traces with many samples, e.g., >10000.
+    :rtype: tuple of (bool, np.array)
+    :returns: Tuple of (interpolate, resp_frequencies) that indicates whether
+        interpolation should be used, and the frequencies for which responses
+        shall be requested (if interpolate=False, then the frequencies that are
+        input are the same that are output).
+    """
+    interpolate = False
+    if n_frequencies_limit_for_interp is None:
+        if len(frequencies) > n_frequencies_limit_for_interp:
+            interpolate = True
+
+    if interpolate:
+        resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                        n_frequencies_limit_for_interp,
+                                        dtype=np.float64)
+    else:
+        resp_frequencies = frequencies
+
+    return interpolate, resp_frequencies
 
 
 if __name__ == '__main__':

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -129,15 +129,15 @@ class ResponseStage(ComparingObject):
         self.description = description
         self.decimation_input_sample_rate = \
             Frequency(decimation_input_sample_rate) \
-            if decimation_input_sample_rate is not None else None
+                if decimation_input_sample_rate is not None else None
         self.decimation_factor = decimation_factor
         self.decimation_offset = decimation_offset
         self.decimation_delay = \
             FloatWithUncertaintiesAndUnit(decimation_delay) \
-            if decimation_delay is not None else None
+                if decimation_delay is not None else None
         self.decimation_correction = \
             FloatWithUncertaintiesAndUnit(decimation_correction) \
-            if decimation_correction is not None else None
+                if decimation_correction is not None else None
 
     def __str__(self):
         ret = (
@@ -222,11 +222,18 @@ class PolesZerosResponseStage(ResponseStage):
         # handled by properties.
         self.pz_transfer_function_type = pz_transfer_function_type
         self.normalization_frequency = normalization_frequency
+        for i, x in enumerate(zeros):
+            if not isinstance(x, ComplexWithUncertainties):
+                zeros[i] = ComplexWithUncertainties(x)
+        self._zeros = zeros
+        for i, x in enumerate(poles):
+            if not isinstance(x, ComplexWithUncertainties):
+                poles[i] = ComplexWithUncertainties(x)
+        self._poles = poles
+        # if we don't have a normalization factor, calculate it (needs P/Z set first)
         if normalization_factor is None:
             normalization_factor = self.calc_normalization_factor()
         self.normalization_factor = float(normalization_factor)
-        self.zeros = zeros
-        self.poles = poles
         super(PolesZerosResponseStage, self).__init__(
             stage_sequence_number=stage_sequence_number,
             input_units=input_units,
@@ -255,8 +262,8 @@ class PolesZerosResponseStage(ResponseStage):
             transfer_fct_type=self.pz_transfer_function_type,
             norm_fact=self.normalization_factor,
             norm_freq=self.normalization_frequency,
-            poles=", ".join(map(str, self.poles)),
-            zeros=", ".join(map(str, self.zeros)))
+            poles=", ".join(map(str, self._poles)),
+            zeros=", ".join(map(str, self._zeros)))
         return ret
 
     def _repr_pretty_(self, p, cycle):
@@ -333,8 +340,8 @@ class PolesZerosResponseStage(ResponseStage):
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
         return paz_to_freq_resp(
-            poles=np.array(self.poles, dtype=np.complex128),
-            zeros=np.array(self.zeros, dtype=np.complex128),
+            poles=np.array(self._poles, dtype=np.complex128),
+            zeros=np.array(self._zeros, dtype=np.complex128),
             scale_fac=self.normalization_factor,
             frequencies=frequencies, freq=False) * self.stage_gain
 
@@ -356,17 +363,17 @@ class PolesZerosResponseStage(ResponseStage):
 
         A0 = 1.0 + (1j * 0.0)
         # TODO: ensure that this coercion to float is valid
-        if self.transfer_function_type == "LAPLACE (HERTZ)":
+        if self.pz_transfer_function_type == "LAPLACE (HERTZ)":
             s = 1j * float(self.normalization_frequency)
-        elif self.transfer_function_type == "LAPLACE (RADIANS/SECOND)":
+        elif self.pz_transfer_function_type == "LAPLACE (RADIANS/SECOND)":
             s = 1j * 2 * pi * float(self.normalization_frequency)
         else:
             print("Don't know how to calculate normalization factor "
                   "for z-transform poles and zeros!")
             return False
-        for p in self.poles:
+        for p in self._poles:
             A0 *= (s - p)
-        for z in self.zeros:
+        for z in self._zeros:
             A0 /= (s - z)
 
         return abs(A0)
@@ -433,10 +440,10 @@ class CoefficientsTypeResponseStage(ResponseStage):
         ret += (
             "\n"
             "\tTransfer function type: {transfer_fct_type}\n"
-            "\tContains {num_count} numerators and {den_count} denominators")\
+            "\tContains {num_count} numerators and {den_count} denominators") \
             .format(
-                transfer_fct_type=self.cf_transfer_function_type,
-                num_count=len(self.numerator), den_count=len(self.denominator))
+            transfer_fct_type=self.cf_transfer_function_type,
+            num_count=len(self.numerator), den_count=len(self.denominator))
         return ret
 
     def _repr_pretty_(self, p, cycle):
@@ -1158,7 +1165,7 @@ class Response(ComparingObject):
 
         # Nothing might be set - just return in that case.
         if set(itertools.chain.from_iterable(v.values()
-               for v in sampling_rates.values())) == {None}:
+                                             for v in sampling_rates.values())) == {None}:
             return sampling_rates
 
         # Find the first set input sampling rate. The output sampling rate
@@ -1189,7 +1196,7 @@ class Response(ComparingObject):
                     si["decimation_factor"] = 1
                 else:
                     si["output_sampling_rate"] = si["input_sampling_rate"] / \
-                        float(si["decimation_factor"])
+                                                 float(si["decimation_factor"])
             if not si["decimation_factor"]:
                 si["decimation_factor"] = int(round(
                     si["input_sampling_rate"] / si["output_sampling_rate"]))
@@ -1484,7 +1491,7 @@ class Response(ComparingObject):
                     all_stages[1][0].input_units = \
                         self.instrument_sensitivity.input_units
                     msg = "Set the input units of stage 1 to the overall " \
-                        "input units."
+                          "input units."
                     warnings.warn(msg)
             if not all_stages[1][0].output_units:
                 if max(all_stages.keys()) == 1 and \
@@ -1492,14 +1499,14 @@ class Response(ComparingObject):
                     all_stages[1][0].output_units = \
                         self.instrument_sensitivity.output_units
                     msg = "Set the output units of stage 1 to the overall " \
-                        "output units."
+                          "output units."
                     warnings.warn(msg)
                 if 2 in all_stages and all_stages[2] and \
                         all_stages[2][0].input_units:
                     all_stages[1][0].output_units = \
                         all_stages[2][0].input_units
                     msg = "Set the output units of stage 1 to the input " \
-                        "units of stage 2."
+                          "units of stage 2."
                     warnings.warn(msg)
 
         for stage_number in stage_list:
@@ -1702,11 +1709,11 @@ class Response(ComparingObject):
             if isinstance(blockette, PolesZerosResponseStage) and \
                     blockette.stage_gain and \
                     None in set([
-                        blockette.decimation_correction,
-                        blockette.decimation_delay,
-                        blockette.decimation_factor,
-                        blockette.decimation_input_sample_rate,
-                        blockette.decimation_offset]):
+                blockette.decimation_correction,
+                blockette.decimation_delay,
+                blockette.decimation_factor,
+                blockette.decimation_input_sample_rate,
+                blockette.decimation_offset]):
                 # Don't modify the original object.
                 blockette = copy.deepcopy(blockette)
                 blockette.decimation_correction = 0.0

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -355,7 +355,7 @@ class PolesZerosResponseStage(ResponseStage):
         from obspy.signal.invsim import paz_to_freq_resp
 
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp)
+            frequencies, n_frequencies_limit_for_interp, space='log')
 
         resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
@@ -366,7 +366,9 @@ class PolesZerosResponseStage(ResponseStage):
         # If required, do interpolation of amplitude and phase of the response
         if interpolate:
             amp = np.abs(resp)
-            phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+            # phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+            #phase = np.unwrap(np.angle(resp, deg=False))
+            phase = np.angle(resp)
             amp = _interpolate(resp_frequencies, amp, frequencies)
             phase = _interpolate(resp_frequencies, phase, frequencies)
             final_resp = np.zeros_like(frequencies) + 0j
@@ -568,7 +570,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         # Check if interpolation is required so save time for long traces.
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp)
+            frequencies, n_frequencies_limit_for_interp, 'log')
 
         # While most cases we expect this to represent a Bkt. 54 and
         # thus not have a denominator, if the transfer function is
@@ -602,6 +604,10 @@ class CoefficientsTypeResponseStage(ResponseStage):
                     resp += den * (np.cos(-idx * w) + np.sin(-idx * w) * 1j)
                 amp /= abs(resp)
                 phase -= np.arctan2(resp.imag, resp.real)
+
+                if interpolate:
+                    amp = _interpolate(w, amp, frequencies)
+                    phase = _interpolate(w, phase, frequencies)
 
                 return amp * np.cos(phase) + amp * np.sin(phase) * 1j
         elif self.cf_transfer_function_type == "ANALOG (RADIANS/SECOND)":
@@ -826,6 +832,8 @@ class FIRResponseStage(ResponseStage):
             number of frequencies, the response curve is interpolated. Speeds
             up response-calculation for traces with many samples, e.g., >10000.
         """
+        # seems ok with linear spaced values
+
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
             return np.ones_like(frequencies) * self.stage_gain
@@ -842,7 +850,7 @@ class FIRResponseStage(ResponseStage):
         # Compute response for a limited number of frequencies and interpolate
         # inbetween - 10000 appears fine for high precision and speed.
         interpolate, resp_frequencies = _check_response_interpolation(
-            frequencies, n_frequencies_limit_for_interp)
+            frequencies, n_frequencies_limit_for_interp, 'lin')
 
         resp = scipy.signal.freqz(b=coefficients, a=[1.],
                                   worN=resp_frequencies)[1]
@@ -2720,7 +2728,8 @@ def _pitick2latex(x):
     return string
 
 
-def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
+def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp,
+                                  space='lin'):
     """
     Helper function to check whether the calculation of the response for a set
     of frequencies shall use interpolation or not.
@@ -2743,9 +2752,24 @@ def _check_response_interpolation(frequencies, n_frequencies_limit_for_interp):
             interpolate = True
 
     if interpolate:
-        resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
-                                        n_frequencies_limit_for_interp,
-                                        dtype=np.float64)
+        if space.lower() == 'lin':
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           n_frequencies_limit_for_interp,
+                                           dtype=np.float64)
+        elif space.lower() == 'log':
+            # If the first frequency is zero, then we need to add the zero after
+            # the logspace has been created.
+            if frequencies[0] == 0:
+                resp_frequencies = np.logspace(np.log10(frequencies[1]),
+                                            np.log10(frequencies[-1]),
+                                            n_frequencies_limit_for_interp-1,
+                                            dtype=np.float64)
+                resp_frequencies = np.concatenate((np.zeros(1), resp_frequencies))
+            else:
+                resp_frequencies = np.logspace(np.log10(frequencies[1]),
+                                            np.log10(frequencies[-1]),
+                                            n_frequencies_limit_for_interp,
+                                            dtype=np.float64)
     else:
         resp_frequencies = frequencies
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -993,7 +993,8 @@ class Response(ComparingObject):
         stages = self.response_stages[slice(start_stage, end_stage)]
         resp = stages.pop(0).get_response(frequencies=frequencies)
         for stage in stages[1:]:
-            resp *= stage.get_response(frequencies=frequencies)
+            if 'get_response' in dir(stage):
+                resp *= stage.get_response(frequencies=frequencies)
 
         # For the scaling - run the whole chain once again with the
         # reference frequency.
@@ -1002,7 +1003,8 @@ class Response(ComparingObject):
             stages = self.response_stages[slice(start_stage, end_stage)]
             ref = stages.pop(0).get_response(frequencies=f)
             for stage in stages[1:]:
-                ref *= stage.get_response(frequencies=f)
+                if 'get_response' in dir(stage):
+                    ref *= stage.get_response(frequencies=f)
             resp *= self.instrument_sensitivity.value / np.abs(ref[0])
 
         # By now the response is in the input units of the first stage.

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -1034,8 +1034,7 @@ class Response(ComparingObject):
         stages = self.response_stages[slice(start_stage, end_stage)]
         resp = stages.pop(0).get_response(frequencies=frequencies)
         for stage in stages[1:]:
-            if 'get_response' in dir(stage):
-                resp *= stage.get_response(frequencies=frequencies)
+            resp *= stage.get_response(frequencies=frequencies)
 
         # For the scaling - run the whole chain once again with the
         # reference frequency.

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -808,7 +808,10 @@ class FIRResponseStage(ResponseStage):
             new_values.append(x)
         self._coefficients = new_values
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
+        """
+        Given Computes the 
+        """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
             return np.ones_like(frequencies) * self.stage_gain

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -947,6 +947,48 @@ class Response(ComparingObject):
         else:
             raise ValueError("Unknown unit '%s'." % unit)
 
+    def get_response_for_window_size(self, t_samp, nfft, output="VEL",
+                                     start_stage=None, end_stage=None):
+        """
+        Returns frequency response and corresponding frequencies for
+        the given sample rate delta and FFT window size
+
+        :type t_samp: float
+        :param t_samp: time resolution (inverse frequency resolution)
+        :type nfft: int
+        :param nfft: Number of FFT points to use
+        :type output: str
+        :param output: Output units. One of:
+
+            ``"DISP"``
+                displacement, output unit is meters
+            ``"VEL"``
+                velocity, output unit is meters/second
+            ``"ACC"``
+                acceleration, output unit is meters/second**2
+
+        :type start_stage: int, optional
+        :param start_stage: Stage sequence number of first stage that will be
+            used (disregarding all earlier stages).
+        :type end_stage: int, optional
+        :param end_stage: Stage sequence number of last stage that will be
+            used (disregarding all later stages).
+        :rtype: tuple of two arrays
+        :returns: frequency response and corresponding frequencies
+        """
+        # Calculate the output frequencies.
+        fy = 1 / (t_samp * 2.0)
+        # start at zero to get zero for offset/ DC of fft
+        # numpy 1.9 introduced a dtype kwarg
+        try:
+            freqs = np.linspace(0, fy, int(nfft // 2) + 1, dtype=np.float64)
+        except Exception:
+            freqs = np.linspace(0, fy, int(nfft // 2) + 1).astype(np.float64)
+
+        response = self.get_response(
+            freqs, output=output, start_stage=start_stage, end_stage=end_stage)
+        return response, freqs
+
     def get_response(self, frequencies, output="velocity", start_stage=None,
                      end_stage=None):
         """
@@ -2059,7 +2101,7 @@ class Response(ComparingObject):
         nyquist = sampling_rate / 2.0
         nfft = int(sampling_rate / min_freq)
 
-        cpx_response, freq = self.get_evalresp_response(
+        cpx_response, freq = self.get_response_for_window_size(
             t_samp=t_samp, nfft=nfft, output=output, start_stage=start_stage,
             end_stage=end_stage)
 

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -177,11 +177,11 @@ class ResponseStage(ComparingObject):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
 
-    def get_response(self, frequencies, fast=True):
+    def get_response(self, frequencies, n_frequencies_limit_for_interp=None):
         """
         :param frequencies: Frequency range to get resp curve over
-        :param fast: Dummy argument to make function similar to
-                     get_response-functions for other stage-types.
+        :param n_frequencies_limit_for_interp: Dummy argument to make function
+            similar to get_response-functions for other stage-types.
         :return: The curve describing this response stage
         """
         # if a response stage isn't a subclass then it's likely a gain stage.
@@ -341,20 +341,27 @@ class PolesZerosResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies, fast=True):
+    def get_response(self, frequencies, n_frequencies_limit_for_interp=10000):
         """
         Produce the response curve from this stage's data for a given
         range of frequencies
         :param frequencies: Frequency range to get resp curve over
-        :param fast: Indicates whether to speed up calculation through
+        :param n_frequencies_limit_for_interp: Indicates a limit for the number
+            of frequencies (=number of samples in a trace) for which the
+            response curve is calculated. Above this number of frequencies, the
+            response curve is interpolated. Speeds up response-calculation for
+            traces with many samples, e.g., >10000.
+        Indicates whether to speed up calculation through
             interpolation.
         :return: The curve describing this response stage
         """
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
-        if len(frequencies) > 10000 and fast:
-            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
-                                           10000, dtype=np.float64)
+        if n_frequencies_limit_for_interp is not None:
+            if len(frequencies) > n_frequencies_limit_for_interp:
+                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                               n_frequencies_limit_for_interp,
+                                               dtype=np.float64)
         else:
             resp_frequencies = frequencies
 
@@ -365,16 +372,17 @@ class PolesZerosResponseStage(ResponseStage):
             frequencies=resp_frequencies, freq=False) * self.stage_gain
 
         # If required, do interpolation of amplitude and phase of the response
-        if len(frequencies) > 10000 and fast:
-            amp = np.abs(resp)
-            phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                resp_frequencies, amp, k=2)(frequencies)
-            phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                resp_frequencies, phase, k=2)(frequencies)
-            final_resp = np.zeros_like(frequencies) + 0j
-            final_resp.real = amp * np.cos(phase)
-            final_resp.imag = amp * np.sin(phase)
+        if n_frequencies_limit_for_interp is not None:
+            if len(frequencies) > n_frequencies_limit_for_interp:
+                amp = np.abs(resp)
+                phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+                amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=3)(frequencies)
+                phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=3)(frequencies)
+                final_resp = np.zeros_like(frequencies) + 0j
+                final_resp.real = amp * np.cos(phase)
+                final_resp.imag = amp * np.sin(phase)
         else:
             final_resp = resp
 
@@ -550,13 +558,16 @@ class CoefficientsTypeResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies, fast=True):
+    def get_response(self, frequencies, n_frequencies_limit_for_interp=10000):
         """
         Produce the response curve from this coefficient
         response stage for a range of frequencies
         :param frequencies: Frequency range to get resp curve over
-        :param fast: Indicates whether to speed up calculation through
-            interpolation.
+        :param n_frequencies_limit_for_interp: Indicates a limit for the number
+            of frequencies (=number of samples in a trace) for which the
+            response curve is calculated. Above this number of frequencies, the
+            response curve is interpolated. Speeds up response-calculation for
+            traces with many samples, e.g., >10000.
         :return: The curve describing this response stage
         """
         # Decimation blockette, e.g. gain only!
@@ -567,9 +578,11 @@ class CoefficientsTypeResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
 
         # Check if interpolation is required so save time for long traces.
-        if len(frequencies) > 10000 and fast:
-            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
-                                           10000, dtype=np.float64)
+        if n_frequencies_limit_for_interp is not None:
+            if len(frequencies) > n_frequencies_limit_for_interp:
+                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                               n_frequencies_limit_for_interp,
+                                               dtype=np.float64)
         else:
             resp_frequencies = frequencies
 
@@ -641,14 +654,16 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if self.cf_transfer_function_type != 'DIGITAL':
             amp *= self.stage_gain / gain_freq_amp
 
-        # If "fast", then interpolate the amplitude and phase onto the
-        # originally requested frequencies.
-        if len(frequencies) > 10000 and fast:
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=2)(frequencies)
-            phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, phase, k=2)(frequencies)
-            final_resp = np.zeros_like(frequencies) + 0j
+        # If an interpolation limit (n_frequencies_limit_for_interp) is set,
+        # then interpolate the amplitude and phase onto the originally
+        # requested frequencies.
+        if n_frequencies_limit_for_interp is not None:
+            if len(frequencies) > n_frequencies_limit_for_interp:
+                amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                        resp_frequencies, amp, k=3)(frequencies)
+                phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                        resp_frequencies, phase, k=3)(frequencies)
+                final_resp = np.zeros_like(frequencies) + 0j
         else:
             final_resp = np.empty_like(resp)
         final_resp.real = amp * np.cos(phase)
@@ -820,12 +835,15 @@ class FIRResponseStage(ResponseStage):
             new_values.append(x)
         self._coefficients = new_values
 
-    def get_response(self, frequencies, fast=True):
+    def get_response(self, frequencies, n_frequencies_limit_for_interp=10000):
         """
         Given Computes the
         :param frequencies: Discrete frequencies to calculate response for.
-        :param fast: Indicates whether to speed up calculation through
-            interpolation.
+        :param n_frequencies_limit_for_interp: Indicates a limit for the number
+            of frequencies (=number of samples in a trace) for which the
+            response curve is calculated. Above this number of frequencies, the
+            response curve is interpolated. Speeds up response-calculation for
+            traces with many samples, e.g., >10000.
         """
         # Decimation blockette, e.g. gain only!
         if not len(self._coefficients):
@@ -842,15 +860,17 @@ class FIRResponseStage(ResponseStage):
         frequencies = frequencies / sr * np.pi * 2.0
         # Compute response for a limited number of frequencies and interpolate
         # inbetween - 10000 appears fine for high precision and speed.
-        if len(frequencies) > 10000 and fast:
-            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
-                                           10000, dtype=np.float64)
-            resp = scipy.signal.freqz(b=coefficients, a=[1.],
-                                      worN=resp_frequencies)[1]
-            amp = np.abs(resp) * self.stage_gain + 0j
-            amp = amp.real
-            amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    resp_frequencies, amp, k=2)(frequencies)
+        if n_frequencies_limit_for_interp is not None:
+            if len(frequencies) > n_frequencies_limit_for_interp:
+                resp_frequencies = np.logspace(frequencies[0], frequencies[-1],
+                                               n_frequencies_limit_for_interp,
+                                               dtype=np.float64)
+                resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                          worN=resp_frequencies)[1]
+                amp = np.abs(resp) * self.stage_gain + 0j
+                amp = amp.real
+                amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                        resp_frequencies, amp, k=3)(frequencies)
         else:
             resp = scipy.signal.freqz(b=coefficients, a=[1.],
                                       worN=frequencies)[1]
@@ -1071,7 +1091,7 @@ class Response(ComparingObject):
 
     def get_response_for_window_size(self, t_samp, nfft, output="VEL",
                                      start_stage=None, end_stage=None,
-                                     fast=True):
+                                     n_frequencies_limit_for_interp=10000):
         """
         Returns frequency response and corresponding frequencies for
         the given sample rate delta and FFT window size
@@ -1110,11 +1130,11 @@ class Response(ComparingObject):
 
         response = self.get_response(
             freqs, output=output, start_stage=start_stage, end_stage=end_stage,
-            fast=fast)
+            n_frequencies_limit_for_interp=n_frequencies_limit_for_interp)
         return response, freqs
 
     def get_response(self, frequencies, output="velocity", start_stage=None,
-                     end_stage=None, fast=True):
+                     end_stage=None, n_frequencies_limit_for_interp=10000):
         """
         Returns the frequency response for given frequencies.
         :type frequencies: list of float
@@ -1133,10 +1153,12 @@ class Response(ComparingObject):
         :type end_stage: int, optional
         :param end_stage: Stage sequence number of last stage that will be
             used (disregarding all later stages).
-        :type fast: bool
-        :param fast: When set to True (default), then the calculation of the
-            response for a large number of frequencies is sped up through
-            interpolation. Relevant for traces with >10000 samples.
+        :type n_frequencies_limit_for_interp: int
+        :param n_frequencies_limit_for_interp: Indicates a limit for the number
+            of frequencies (=number of samples in a trace) for which the
+            response curve is calculated. Above this number of frequencies, the
+            response curve is interpolated. Speeds up response-calculation for
+            traces with many samples, e.g., >10000.
         :rtype: :class:`numpy.ndarray`
         :returns: frequency response at requested frequencies
         """
@@ -1161,10 +1183,14 @@ class Response(ComparingObject):
         stages = self.response_stages[slice(start_stage, end_stage)]
         # map 0j here to ensure the curve is complex values
         # which it may not be if we start on a gain stage
-        resp = stages[0].get_response(frequencies=frequencies, fast=fast) + 0j
+        resp = stages[0].get_response(frequencies=frequencies,
+                                      n_frequencies_limit_for_interp
+                                      =n_frequencies_limit_for_interp) + 0j
         for stage in stages[1:]:
             try:
-                resp *= stage.get_response(frequencies=frequencies, fast=fast)
+                resp *= stage.get_response(frequencies=frequencies,
+                                           n_frequencies_limit_for_interp
+                                           =n_frequencies_limit_for_interp)
             except AttributeError:
                 raise NotImplementedError
 
@@ -1173,9 +1199,13 @@ class Response(ComparingObject):
         if start_stage == 0 and end_stage is None:
             f = np.array([self.instrument_sensitivity.frequency])
             stages = self.response_stages[slice(start_stage, end_stage)]
-            ref = stages[0].get_response(frequencies=f, fast=fast)
+            ref = stages[0].get_response(frequencies=f,
+                                         n_frequencies_limit_for_interp
+                                         =n_frequencies_limit_for_interp)
             for stage in stages[1:]:
-                ref *= stage.get_response(frequencies=f, fast=fast)
+                ref *= stage.get_response(frequencies=f,
+                                          n_frequencies_limit_for_interp
+                                          =n_frequencies_limit_for_interp)
             resp *= self.instrument_sensitivity.value / np.abs(ref[0])
 
         # By now the response is in the input units of the first stage.
@@ -1815,9 +1845,9 @@ class Response(ComparingObject):
                                             max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, amp, k=2)(frequencies)
+                    f, amp, k=3)(frequencies)
                 phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, phase, k=2)(frequencies)
+                    f, phase, k=3)(frequencies)
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0

--- a/obspy/core/inventory/response.py
+++ b/obspy/core/inventory/response.py
@@ -335,7 +335,7 @@ class PolesZerosResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
         """
         Produce the response curve from this stage's data for a given
         range of frequencies
@@ -344,11 +344,33 @@ class PolesZerosResponseStage(ResponseStage):
         """
         # Has to be imported here for now to avoid circular imports.
         from obspy.signal.invsim import paz_to_freq_resp
-        return paz_to_freq_resp(
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+        else:
+            resp_frequencies = frequencies
+            
+        resp = paz_to_freq_resp(
             poles=np.array(self._poles, dtype=np.complex128),
             zeros=np.array(self._zeros, dtype=np.complex128),
             scale_fac=self.normalization_factor,
-            frequencies=frequencies, freq=False) * self.stage_gain
+            frequencies=resp_frequencies, freq=False) * self.stage_gain
+        
+        # If required, do interpolation of amplitude and phase of the response
+        if len(frequencies) > 10000 and fast:
+            amp = np.abs(resp)
+            phase = np.radians(np.unwrap(np.angle(resp, deg=False))) / np.pi
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=2)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
+            final_resp.real = amp * np.cos(phase)
+            final_resp.imag = amp * np.sin(phase)
+        else:
+            final_resp = resp
+        
+        return final_resp
 
     def calc_normalization_factor(self):
         """
@@ -520,7 +542,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         else:
             raise ValueError(msg)
 
-    def get_response(self, frequencies):
+    def get_response(self, frequencies, fast=True):
         """
         Produce the response curve from this coefficient
         response stage for a range of frequencies
@@ -533,6 +555,13 @@ class CoefficientsTypeResponseStage(ResponseStage):
 
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
+        
+        # Check if interpolation is required so save time for long traces.
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+        else:
+            resp_frequencies = frequencies
 
         # While most cases we expect this to represent a Bkt. 54 and
         # thus not have a denominator, if the transfer function is
@@ -540,7 +569,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
         if self.cf_transfer_function_type == "DIGITAL":
             if len(self.denominator) == 0:
                 resp = scipy.signal.freqz(b=self.numerator,
-                                          a=[1.], worN=frequencies)[1]
+                                          a=[1.], worN=resp_frequencies)[1]
 
                 gain_freq_amp = np.abs(scipy.signal.freqz(
                     b=self.numerator, a=[1.],
@@ -551,7 +580,7 @@ class CoefficientsTypeResponseStage(ResponseStage):
                 # we get the numerator and denominator and do the math
                 # on them in their representation as magnitude and
                 # phase rather than standard complex format
-                w = frequencies  # rename to be concise and match conventions
+                w = resp_frequencies  # rename to be concise and match conventions
 
                 resp = np.zeros_like(w) + 0j
                 for idx, num in enumerate(self.numerator):
@@ -569,14 +598,15 @@ class CoefficientsTypeResponseStage(ResponseStage):
         elif self.cf_transfer_function_type == "ANALOG (RADIANS/SECOND)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=frequencies / (np.pi * 2.0))[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies\
+                    / (np.pi * 2.0))[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency / (np.pi * 2.0)])[1])
         elif self.cf_transfer_function_type == "ANALOG (HERTZ)":
             # XXX: Untested so far!
             resp = scipy.signal.freqs(
-                b=self.numerator, a=[1.0], worN=frequencies)[1]
+                b=self.numerator, a=[1.0], worN=resp_frequencies)[1]
             gain_freq_amp = np.abs(scipy.signal.freqs(
                 b=self.numerator, a=[1.0],
                 worN=[self.stage_gain_frequency])[1])
@@ -598,7 +628,17 @@ class CoefficientsTypeResponseStage(ResponseStage):
         # evalresp does this and thus so do we.
         if self.cf_transfer_function_type != 'DIGITAL':
             amp *= self.stage_gain / gain_freq_amp
-        final_resp = np.empty_like(resp)
+        
+        # If "fast", then interpolate the amplitude and phase onto the
+        # originally requested frequencies.
+        if len(frequencies) > 10000 and fast:
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+            phase = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, phase, k=2)(frequencies)
+            final_resp = np.zeros_like(frequencies) + 0j
+        else:
+            final_resp = np.empty_like(resp)
         final_resp.real = amp * np.cos(phase)
         final_resp.imag = amp * np.sin(phase)
 
@@ -782,9 +822,23 @@ class FIRResponseStage(ResponseStage):
             coefficients = self._coefficients
         sr = self.decimation_input_sample_rate
         frequencies = frequencies / sr * np.pi * 2.0
-        resp = scipy.signal.freqz(b=coefficients, a=[1.], worN=frequencies)[1]
-        # Here we zero the phase (FIR) and return the amplitude
-        amp = np.abs(resp) * self.stage_gain + 0j
+        # Compute response for a limited number of frequencies and interpolate
+        # inbetween - 10000 appears fine for high precision and speed.
+        if len(frequencies) > 10000 and fast:
+            resp_frequencies = np.linspace(frequencies[0], frequencies[-1],
+                                           10000, dtype=np.float64)
+            resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                      worN=resp_frequencies)[1]
+            amp = np.abs(resp) * self.stage_gain + 0j
+            amp = amp.real
+            amp = scipy.interpolate.InterpolatedUnivariateSpline(
+                    resp_frequencies, amp, k=2)(frequencies)
+        else:
+            resp = scipy.signal.freqz(b=coefficients, a=[1.],
+                                      worN=frequencies)[1]
+            # Here we zero the phase (FIR) and return the amplitude
+            amp = np.abs(resp) * self.stage_gain + 0j
+            amp = amp.real
         return amp
 
 
@@ -1040,7 +1094,7 @@ class Response(ComparingObject):
         return response, freqs
 
     def get_response(self, frequencies, output="velocity", start_stage=None,
-                     end_stage=None):
+                     end_stage=None, fast=True):
         """
         Returns the frequency response for given frequencies.
         :type frequencies: list of float
@@ -1737,9 +1791,9 @@ class Response(ComparingObject):
                                             max_f))
 
                 amp = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, amp, k=3)(frequencies)
+                    f, amp, k=2)(frequencies)
                 phase = scipy.interpolate.InterpolatedUnivariateSpline(
-                    f, phase, k=3)(frequencies)
+                    f, phase, k=2)(frequencies)
 
                 # Set static offset to zero.
                 amp[amp == 0] = 0

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -146,7 +146,7 @@ class ResponseTestCase(unittest.TestCase):
             print("passed:", xml_filename)
 
     def test_get_response_per_stage(self):
-        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
+        filenames = ["AU.MEEK", "IU_ANMO_00_BHZ", "IRIS_single_channel_with_response", "XM.05"]
         units = ["DISP", "VEL", "ACC"]
 
         for filename in filenames:
@@ -291,6 +291,28 @@ class ResponseTestCase(unittest.TestCase):
                     freqs, output=unit)
                 expected = [seed_response[i_] for i_ in indices]
                 np.testing.assert_allclose(got, expected, rtol=1E-5)
+
+    def test_normalization_calculation(self):
+        zeros = [0, 0,
+                 -4.63100e+02 + 4.63100e+02j,
+                 -4.63100e+02 - 4.63100e+02j,
+                 -8.59502,
+                 -1.59005e+02]
+        poles = [-3.71864e-02 + 3.69685e-02,
+                 -3.71864e-02 - 3.69685e-02,
+                 -3.74800e+02,
+                 -5.20300e+02,
+                 -1.05300e+03 - 1.00500e+03,
+                 -1.05300e+03 + 1.00500e+03,
+                 -1.33000e+04,
+                 -8.96456,
+                 -9.20285e+01 + 3.96113e+02,
+                 -2.50919e+02]
+        stage = PolesZerosResponseStage(stage_sequence_number=1, stage_gain=1.957300e+04,
+                                        stage_gain_frequency=0.2, input_units='M/S', output_units='V',
+                                        pz_transfer_function_type='LAPLACE (RADIANS/SECOND)',
+                                        normalization_frequency=2E-2, zeros=zeros, poles=poles)
+        self.assertAlmostEqual(3.471289E+11, stage.normalization_factor, delta=1E6)
 
     def test_pitick2latex(self):
         self.assertEqual(_pitick2latex(3 * pi / 2), r'$\frac{3\pi}{2}$')

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -21,7 +21,8 @@ from matplotlib import rcParams
 
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
-    _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, ResponseStage)
+    _pitick2latex,
+    PolesZerosResponseStage, PolynomialResponseStage)
 from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
@@ -117,7 +118,8 @@ class ResponseTestCase(unittest.TestCase):
 
     def test_get_response_regression(self):
         units = ["DISP", "VEL", "ACC"]
-        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
+        filenames = ["AU.MEEK", "IRIS_single_channel_with_response",
+                     "XM.05", "IU_ANMO_00_BHZ"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
@@ -146,7 +148,8 @@ class ResponseTestCase(unittest.TestCase):
             print("passed:", xml_filename)
 
     def test_get_response_per_stage(self):
-        filenames = ["AU.MEEK", "IU_ANMO_00_BHZ", "IRIS_single_channel_with_response", "XM.05"]
+        filenames = ["AU.MEEK", "IU_ANMO_00_BHZ",
+                     "IRIS_single_channel_with_response", "XM.05"]
         units = ["DISP", "VEL", "ACC"]
 
         for filename in filenames:
@@ -158,27 +161,28 @@ class ResponseTestCase(unittest.TestCase):
             print(xml_filename)
             for unit in units:
                 for x in range(1, len(resp.response_stages)+1):
-                    """
-                    if not isinstance(resp.response_stages[x-1], FIRResponseStage):
-                        continue
-                    """
-                    print("Type of stage ", str(x) + ":", type(resp.response_stages[x-1]))
+                    print("Type of stage ", str(x) +
+                          ":", type(resp.response_stages[x-1]))
                     xml_resp = resp.get_evalresp_response_for_frequencies(
-                        frequencies=freqs, start_stage=x, end_stage=x, output=unit)
+                        frequencies=freqs, start_stage=x,
+                        end_stage=x, output=unit)
                     new_resp = resp.get_response(
-                        frequencies=freqs, start_stage=x, end_stage=x, output=unit)
+                        frequencies=freqs, start_stage=x,
+                        end_stage=x, output=unit)
 
                     np.testing.assert_allclose(np.abs(xml_resp),
                                                np.abs(new_resp), rtol=1E-5)
-                    # Phase starts to differ slightly before Nyquist and quite a
-                    # bit after. Evalresp appears to have some Gibb's artifacts
-                    # and scipy's solution does look better.
+                    # Phase starts to differ slightly before
+                    # Nyquist and quite a bit after. Evalresp
+                    # appears to have some Gibb's artifacts and scipy's
+                    # solution does look better.
                     np.testing.assert_allclose(
                         np.unwrap(np.angle(xml_resp))[:800],
                         np.unwrap(np.angle(new_resp))[:800],
                         rtol=1E-2, atol=2E-2)
 
-                    print("Succeeded with case for stage no.", x, "with units", unit)
+                    print("Succeeded with case for stage no.", x,
+                          "with units", unit)
 
     def test_get_response_disp_vel_acc(self):
         units = ["DISP", "VEL", "ACC"]
@@ -308,11 +312,15 @@ class ResponseTestCase(unittest.TestCase):
                  -8.96456,
                  -9.20285e+01 + 3.96113e+02,
                  -2.50919e+02]
-        stage = PolesZerosResponseStage(stage_sequence_number=1, stage_gain=1.957300e+04,
-                                        stage_gain_frequency=0.2, input_units='M/S', output_units='V',
+        stage = PolesZerosResponseStage(stage_sequence_number=1,
+                                        stage_gain=1.957300e+04,
+                                        stage_gain_frequency=0.2,
+                                        input_units='M/S', output_units='V',
                                         pz_transfer_function_type='LAPLACE (RADIANS/SECOND)',
-                                        normalization_frequency=2E-2, zeros=zeros, poles=poles)
-        self.assertAlmostEqual(3.471289E+11, stage.normalization_factor, delta=1E6)
+                                        normalization_frequency=2E-2,
+                                        zeros=zeros, poles=poles)
+        self.assertAlmostEqual(3.471289E+11,
+                               stage.normalization_factor, delta=1E6)
 
     def test_pitick2latex(self):
         self.assertEqual(_pitick2latex(3 * pi / 2), r'$\frac{3\pi}{2}$')

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -117,7 +117,7 @@ class ResponseTestCase(unittest.TestCase):
 
     def test_get_response_regression(self):
         units = ["DISP", "VEL", "ACC"]
-        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ", "AU.MEEK"]
+        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
@@ -129,25 +129,24 @@ class ResponseTestCase(unittest.TestCase):
 
             for unit in units:
                 # Full response.
-                xml_resp = resp.get_evalresp_response_for_frequencies(
+                evrs_resp = resp.get_evalresp_response_for_frequencies(
                     frequencies=freqs, output=unit)
                 new_resp = resp.get_response(
                     frequencies=freqs, output=unit)
 
-                np.testing.assert_allclose(np.abs(xml_resp),
+                np.testing.assert_allclose(np.abs(evrs_resp),
                                            np.abs(new_resp), rtol=1E-5)
                 # Phase starts to differ slightly before Nyquist and quite a
                 # bit after. Evalresp appears to have some Gibb's artifacts
                 # and scipy's solution does look better.
                 np.testing.assert_allclose(
-                    np.unwrap(np.angle(xml_resp))[:800],
+                    np.unwrap(np.angle(evrs_resp))[:800],
                     np.unwrap(np.angle(new_resp))[:800],
                     rtol=1E-2, atol=2E-2)
             print("passed:", xml_filename)
 
     def test_get_response_per_stage(self):
-        from obspy.core.inventory import FIRResponseStage
-        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ", "AU.MEEK"]
+        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
         units = ["DISP", "VEL", "ACC"]
 
         for filename in filenames:
@@ -159,13 +158,11 @@ class ResponseTestCase(unittest.TestCase):
             print(xml_filename)
             for unit in units:
                 for x in range(1, len(resp.response_stages)+1):
-                    print(type(resp.response_stages[x - 1]))
                     """
                     if not isinstance(resp.response_stages[x-1], FIRResponseStage):
-                        print("skipping...")
                         continue
                     """
-
+                    print("Type of stage ", str(x) + ":", type(resp.response_stages[x-1]))
                     xml_resp = resp.get_evalresp_response_for_frequencies(
                         frequencies=freqs, start_stage=x, end_stage=x, output=unit)
                     new_resp = resp.get_response(

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -21,7 +21,7 @@ from matplotlib import rcParams
 
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
-    _pitick2latex,
+    _pitick2latex, Response,
     PolesZerosResponseStage, PolynomialResponseStage)
 from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -45,6 +45,153 @@ class ResponseTestCase(unittest.TestCase):
     def tearDown(self):
         np.seterr(**self.nperr)
 
+    def test_get_response(self):
+        unit = "VEL"
+        filename = "IRIS_single_channel_with_response"
+
+        xml_filename = os.path.join(self.data_dir,
+                                    filename + os.path.extsep + "xml")
+        inv = read_inventory(xml_filename)
+        resp = inv[0][0][0].response
+
+        freqs = np.logspace(-2, 2, 1000)
+
+        # PAZ stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=1,
+            end_stage=1)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=1,
+            end_stage=1)
+        np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+        np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+
+        # Decimation stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=2,
+            end_stage=2)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=2,
+            end_stage=2)
+        np.testing.assert_allclose(xml_resp.real, new_resp.real, rtol=1E-6)
+        np.testing.assert_allclose(xml_resp.imag, new_resp.imag, rtol=1E-6)
+
+        # Coefficients stage.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit,
+            start_stage=3,
+            end_stage=3)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit,
+            start_stage=3,
+            end_stage=3)
+        # Amplitude if fully identical everywhere.
+        np.testing.assert_allclose(np.abs(xml_resp), np.abs(new_resp))
+        # Phase starts to differ slightly before Nyquist and quite a bit
+        # after. Evalresp appears to have some Gibb's artifacts and
+        # scipy's solution does look better.
+        np.testing.assert_allclose(
+            np.unwrap(np.angle(xml_resp))[:800],
+            np.unwrap(np.angle(new_resp))[:800],
+            rtol=1E-2, atol=2E-2)
+
+        # Full response.
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit)
+
+        np.testing.assert_allclose(np.abs(xml_resp),
+                                   np.abs(new_resp), rtol=1E-5)
+        # Phase starts to differ slightly before Nyquist and quite a bit
+        # after. Evalresp appears to have some Gibb's artifacts and
+        # scipy's solution does look better.
+        np.testing.assert_allclose(
+            np.unwrap(np.angle(xml_resp))[:800],
+            np.unwrap(np.angle(new_resp))[:800],
+            rtol=1E-2, atol=2E-2)
+
+    def test_get_response_regression(self):
+        units = ["DISP", "VEL", "ACC"]
+        filenames = ["IRIS_single_channel_with_response", "XM.05", "AU.MEEK"]
+
+        for filename in filenames:
+            xml_filename = os.path.join(self.data_dir,
+                                        filename + os.path.extsep + "xml")
+            inv = read_inventory(xml_filename)
+            resp = inv[0][0][0].response
+
+            freqs = np.logspace(-2, 2, 1000)
+
+            for unit in units:
+                # Full response.
+                xml_resp = resp.get_evalresp_response_for_frequencies(
+                    frequencies=freqs, output=unit)
+                new_resp = resp.get_response(
+                    frequencies=freqs, output=unit)
+
+                np.testing.assert_allclose(np.abs(xml_resp),
+                                           np.abs(new_resp), rtol=1E-5)
+                # Phase starts to differ slightly before Nyquist and quite a
+                # bit after. Evalresp appears to have some Gibb's artifacts
+                # and scipy's solution does look better.
+                np.testing.assert_allclose(
+                    np.unwrap(np.angle(xml_resp))[:800],
+                    np.unwrap(np.angle(new_resp))[:800],
+                    rtol=1E-2, atol=2E-2)
+
+    def test_get_response_disp_vel_acc(self):
+        units = ["DISP", "VEL", "ACC"]
+        filename = "IRIS_single_channel_with_response"
+
+        xml_filename = os.path.join(self.data_dir,
+                                    filename + os.path.extsep + "xml")
+        inv = read_inventory(xml_filename)
+        resp = inv[0][0][0].response
+
+        freqs = np.logspace(-2, 2, 1000)
+
+        for unit in units:
+            # Full response.
+            xml_resp = resp.get_evalresp_response_for_frequencies(
+                frequencies=freqs, output=unit)
+            new_resp = resp.get_response(
+                frequencies=freqs, output=unit)
+
+            np.testing.assert_allclose(np.abs(xml_resp),
+                                       np.abs(new_resp), rtol=1E-5)
+            # Phase starts to differ slightly before Nyquist and quite a bit
+            # after. Evalresp appears to have some Gibb's artifacts and
+            # scipy's solution does look better.
+            np.testing.assert_allclose(
+                np.unwrap(np.angle(xml_resp))[:800],
+                np.unwrap(np.angle(new_resp))[:800],
+                rtol=1E-2, atol=2E-2)
+
+            # import matplotlib.pyplot as plt
+            # plt.subplot(411)
+            # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
+            # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
+            # plt.legend(loc=3)
+            # plt.subplot(412)
+            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
+            # plt.subplot(413)
+            #
+            # new_phase = np.angle(new_resp)
+            # xml_phase = np.angle(xml_resp)
+            #
+            # plt.semilogx(freqs, xml_phase, label="evalresp")
+            # plt.semilogx(freqs, new_phase, label="scipy")
+            # plt.legend(loc=3)
+            # plt.xlim(1E-2, 20.0)
+            # plt.subplot(414)
+            # plt.semilogx(freqs,xml_phase - new_phase)
+            # plt.show()
+
     def test_evalresp_with_output_from_seed(self):
         """
         The StationXML file has been converted to SEED with the help of a tool

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -652,7 +652,7 @@ class ResponseTestCase(unittest.TestCase):
         inv = read_inventory(os.path.join(self.data_dir, "IM_I53H1_BDF.xml"))
         self.assertEqual(
             0.0 + 0.0j,
-            inv[0][0][0].response.get_evalresp_response_for_frequencies([0.0])[0])
+            inv[0][0][0].response.get_evalresp_response_for_frequencies([0.0]))
         np.testing.assert_allclose(
             inv[0][0][0].response.get_evalresp_response_for_frequencies(
                 [0.1, 1.0, 10.0]),

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -117,7 +117,7 @@ class ResponseTestCase(unittest.TestCase):
 
     def test_get_response_regression(self):
         units = ["DISP", "VEL", "ACC"]
-        filenames = ["IRIS_single_channel_with_response", "XM.05", "AU.MEEK", "IU_ANMO_00_BHZ"]
+        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ", "AU.MEEK"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
@@ -143,37 +143,37 @@ class ResponseTestCase(unittest.TestCase):
                     np.unwrap(np.angle(xml_resp))[:800],
                     np.unwrap(np.angle(new_resp))[:800],
                     rtol=1E-2, atol=2E-2)
+            print("passed:", xml_filename)
 
     def test_get_response_per_stage(self):
-        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
+        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ", "AU.MEEK"]
+        units = ["DISP", "VEL", "ACC"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
                                         filename + os.path.extsep + "xml")
             inv = read_inventory(xml_filename)
             resp = inv[0][0][0].response
-
             freqs = np.logspace(-2, 2, 1000)
             print(xml_filename, '\n', resp.response_stages)
-            for x in range(1, len(resp.response_stages)):
-                xml_resp = resp.get_evalresp_response_for_frequencies(
-                    frequencies=freqs, start_stage=x, end_stage=x)
-                new_resp = resp.get_response(
-                    frequencies=freqs, start_stage=x, end_stage=x)
+            for unit in units:
+                for x in range(1, len(resp.response_stages)):
+                    xml_resp = resp.get_evalresp_response_for_frequencies(
+                        frequencies=freqs, start_stage=x, end_stage=x, output=unit)
+                    new_resp = resp.get_response(
+                        frequencies=freqs, start_stage=x, end_stage=x, output=unit)
 
-                np.testing.assert_allclose(np.abs(xml_resp),
-                                           np.abs(new_resp), rtol=1E-5)
-                # Phase starts to differ slightly before Nyquist and quite a
-                # bit after. Evalresp appears to have some Gibb's artifacts
-                # and scipy's solution does look better.
-                np.testing.assert_allclose(
-                    np.unwrap(np.angle(xml_resp))[:800],
-                    np.unwrap(np.angle(new_resp))[:800],
-                    rtol=1E-2, atol=2E-2)
+                    np.testing.assert_allclose(np.abs(xml_resp),
+                                               np.abs(new_resp), rtol=1E-5)
+                    # Phase starts to differ slightly before Nyquist and quite a
+                    # bit after. Evalresp appears to have some Gibb's artifacts
+                    # and scipy's solution does look better.
+                    np.testing.assert_allclose(
+                        np.unwrap(np.angle(xml_resp))[:800],
+                        np.unwrap(np.angle(new_resp))[:800],
+                        rtol=1E-2, atol=2E-2)
 
-                print("Succeeded with case for stage no.", x)
-
-
+                    print("Succeeded with case for stage no.", x, "with units", unit)
 
     def test_get_response_disp_vel_acc(self):
         units = ["DISP", "VEL", "ACC"]

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -343,10 +343,10 @@ class ResponseTestCase(unittest.TestCase):
         zeros = [2 + 3j, 2, 3j]
         stage = PolesZerosResponseStage(
             1, 1, 1, "", "", "LAPLACE (HERTZ)", 1, zeros, poles)
-        self.assertEqual(type(stage.zeros[0]), ComplexWithUncertainties)
-        self.assertEqual(type(stage.poles[0]), ComplexWithUncertainties)
-        self.assertEqual(stage.poles, poles)
-        self.assertEqual(stage.zeros, zeros)
+        self.assertEqual(ComplexWithUncertainties, type(stage.zeros[0]))
+        self.assertEqual(ComplexWithUncertainties, type(stage.poles[0]))
+        self.assertEqual(poles, stage.poles)
+        self.assertEqual(zeros, stage.zeros)
 
     def test_response_list_stage(self):
         """
@@ -651,8 +651,8 @@ class ResponseTestCase(unittest.TestCase):
         """
         inv = read_inventory(os.path.join(self.data_dir, "IM_I53H1_BDF.xml"))
         self.assertEqual(
-            inv[0][0][0].response.get_evalresp_response_for_frequencies([0.0]),
-            0.0 + 0.0j)
+            0.0 + 0.0j,
+            inv[0][0][0].response.get_evalresp_response_for_frequencies([0.0])[0])
         np.testing.assert_allclose(
             inv[0][0][0].response.get_evalresp_response_for_frequencies(
                 [0.1, 1.0, 10.0]),

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -122,7 +122,6 @@ class ResponseTestCase(unittest.TestCase):
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
                                         filename + os.path.extsep + "xml")
-            print(xml_filename)
             inv = read_inventory(xml_filename)
             resp = inv[0][0][0].response
 
@@ -144,6 +143,35 @@ class ResponseTestCase(unittest.TestCase):
                     np.unwrap(np.angle(xml_resp))[:800],
                     np.unwrap(np.angle(new_resp))[:800],
                     rtol=1E-2, atol=2E-2)
+
+    def test_get_response_per_stage(self):
+        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
+
+        for filename in filenames:
+            xml_filename = os.path.join(self.data_dir,
+                                        filename + os.path.extsep + "xml")
+            inv = read_inventory(xml_filename)
+            resp = inv[0][0][0].response
+
+            freqs = np.logspace(-2, 2, 1000)
+            for x in range(1, len(resp.response_stages)):
+                print(xml_filename, '\n', resp.response_stages[x])
+                xml_resp = resp.get_evalresp_response_for_frequencies(
+                    frequencies=freqs, start_stage=x, end_stage=x+1)
+                new_resp = resp.get_response(
+                    frequencies=freqs, start_stage=x, end_stage=x+1)
+
+                np.testing.assert_allclose(np.abs(xml_resp),
+                                           np.abs(new_resp), rtol=1E-5)
+                # Phase starts to differ slightly before Nyquist and quite a
+                # bit after. Evalresp appears to have some Gibb's artifacts
+                # and scipy's solution does look better.
+                np.testing.assert_allclose(
+                    np.unwrap(np.angle(xml_resp))[:800],
+                    np.unwrap(np.angle(new_resp))[:800],
+                    rtol=1E-2, atol=2E-2)
+
+
 
     def test_get_response_disp_vel_acc(self):
         units = ["DISP", "VEL", "ACC"]

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -115,13 +115,35 @@ class ResponseTestCase(unittest.TestCase):
             np.unwrap(np.angle(new_resp))[:800],
             rtol=1E-2, atol=2E-2)
 
+    def test_MEEK_no_failure(self):
+        import matplotlib.pyplot as plt
+        inv = read_inventory(os.path.join(self.data_dir,'AU.MEEK.xml'))
+
+        resp = inv[0][0][0].response
+        print(resp)
+        freqs = np.logspace(-2, 2, 1000)
+        unit = 'VEL'
+        xml_resp = resp.get_evalresp_response_for_frequencies(
+            frequencies=freqs, output=unit)
+        new_resp = resp.get_response(
+            frequencies=freqs, output=unit)
+
+        print(resp)
+        # print(new_resp)
+
+        fig = plt.figure(1)
+        plt.semilogx(freqs, np.abs(new_resp), label='NEW')
+        plt.semilogx(freqs, np.abs(xml_resp), label='Eval Resp')
+        plt.show()
+
     def test_get_response_regression(self):
         units = ["DISP", "VEL", "ACC"]
-        filenames = ["IRIS_single_channel_with_response", "XM.05", "AU.MEEK"]
+        filenames = ["IRIS_single_channel_with_response", "IU_ANMO_00_BHZ", "XM.05", "AU.MEEK"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
                                         filename + os.path.extsep + "xml")
+            print(xml_filename)
             inv = read_inventory(xml_filename)
             resp = inv[0][0][0].response
 

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -21,7 +21,7 @@ from matplotlib import rcParams
 
 from obspy import UTCDateTime, read_inventory
 from obspy.core.inventory.response import (
-    _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, Response)
+    _pitick2latex, PolesZerosResponseStage, PolynomialResponseStage, ResponseStage)
 from obspy.core.util import MATPLOTLIB_VERSION
 from obspy.core.util.misc import CatchOutput
 from obspy.core.util.obspy_types import ComplexWithUncertainties
@@ -146,6 +146,7 @@ class ResponseTestCase(unittest.TestCase):
             print("passed:", xml_filename)
 
     def test_get_response_per_stage(self):
+        from obspy.core.inventory import FIRResponseStage
         filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ", "AU.MEEK"]
         units = ["DISP", "VEL", "ACC"]
 
@@ -155,9 +156,16 @@ class ResponseTestCase(unittest.TestCase):
             inv = read_inventory(xml_filename)
             resp = inv[0][0][0].response
             freqs = np.logspace(-2, 2, 1000)
-            print(xml_filename, '\n', resp.response_stages)
+            print(xml_filename)
             for unit in units:
-                for x in range(1, len(resp.response_stages)):
+                for x in range(1, len(resp.response_stages)+1):
+                    print(type(resp.response_stages[x - 1]))
+                    """
+                    if not isinstance(resp.response_stages[x-1], FIRResponseStage):
+                        print("skipping...")
+                        continue
+                    """
+
                     xml_resp = resp.get_evalresp_response_for_frequencies(
                         frequencies=freqs, start_stage=x, end_stage=x, output=unit)
                     new_resp = resp.get_response(
@@ -188,39 +196,39 @@ class ResponseTestCase(unittest.TestCase):
 
         for unit in units:
             # Full response.
-            xml_resp = resp.get_evalresp_response_for_frequencies(
+            evrs_resp = resp.get_evalresp_response_for_frequencies(
                 frequencies=freqs, output=unit)
             new_resp = resp.get_response(
                 frequencies=freqs, output=unit)
 
-            np.testing.assert_allclose(np.abs(xml_resp),
+            np.testing.assert_allclose(np.abs(evrs_resp),
                                        np.abs(new_resp), rtol=1E-5)
             # Phase starts to differ slightly before Nyquist and quite a bit
             # after. Evalresp appears to have some Gibb's artifacts and
             # scipy's solution does look better.
             np.testing.assert_allclose(
-                np.unwrap(np.angle(xml_resp))[:800],
+                np.unwrap(np.angle(evrs_resp))[:800],
                 np.unwrap(np.angle(new_resp))[:800],
                 rtol=1E-2, atol=2E-2)
 
             # import matplotlib.pyplot as plt
             # plt.subplot(411)
-            # plt.semilogx(freqs, np.abs(xml_resp), label="evalresp")
+            # plt.semilogx(freqs, np.abs(evrs_resp), label="evalresp")
             # plt.semilogx(freqs, np.abs(new_resp), label="scipy")
             # plt.legend(loc=3)
             # plt.subplot(412)
-            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(xml_resp))
+            # plt.semilogx(freqs, np.abs(new_resp) - np.abs(evrs_resp))
             # plt.subplot(413)
             #
             # new_phase = np.angle(new_resp)
-            # xml_phase = np.angle(xml_resp)
+            # evrs_phase = np.angle(evrs_resp)
             #
-            # plt.semilogx(freqs, xml_phase, label="evalresp")
+            # plt.semilogx(freqs, evrs_phase, label="evalresp")
             # plt.semilogx(freqs, new_phase, label="scipy")
             # plt.legend(loc=3)
             # plt.xlim(1E-2, 20.0)
             # plt.subplot(414)
-            # plt.semilogx(freqs,xml_phase - new_phase)
+            # plt.semilogx(freqs, evrs_phase - new_phase)
             # plt.show()
 
     def test_evalresp_with_output_from_seed(self):

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -115,30 +115,9 @@ class ResponseTestCase(unittest.TestCase):
             np.unwrap(np.angle(new_resp))[:800],
             rtol=1E-2, atol=2E-2)
 
-    def test_MEEK_no_failure(self):
-        import matplotlib.pyplot as plt
-        inv = read_inventory(os.path.join(self.data_dir,'AU.MEEK.xml'))
-
-        resp = inv[0][0][0].response
-        print(resp)
-        freqs = np.logspace(-2, 2, 1000)
-        unit = 'VEL'
-        xml_resp = resp.get_evalresp_response_for_frequencies(
-            frequencies=freqs, output=unit)
-        new_resp = resp.get_response(
-            frequencies=freqs, output=unit)
-
-        print(resp)
-        # print(new_resp)
-
-        fig = plt.figure(1)
-        plt.semilogx(freqs, np.abs(new_resp), label='NEW')
-        plt.semilogx(freqs, np.abs(xml_resp), label='Eval Resp')
-        plt.show()
-
     def test_get_response_regression(self):
         units = ["DISP", "VEL", "ACC"]
-        filenames = ["IRIS_single_channel_with_response", "IU_ANMO_00_BHZ", "XM.05", "AU.MEEK"]
+        filenames = ["IRIS_single_channel_with_response", "XM.05", "AU.MEEK", "IU_ANMO_00_BHZ"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -484,7 +484,7 @@ class ResponseTestCase(unittest.TestCase):
                                  stage_gain_frequency=5.0,
                                  normalization_frequency=5.0,
                                  normalization_factor=1.070401)
-        paz_resp = resp.get_evalresp_response(.1, 2**6, output='VEL')
+        paz_resp = resp.get_response_for_window_size(.1, 2 ** 6, output='VEL')
         np.testing.assert_allclose(paz_resp, loaded_resp)
 
     def test_str_method_of_the_polynomial_response_stage(self):

--- a/obspy/core/tests/test_response.py
+++ b/obspy/core/tests/test_response.py
@@ -145,7 +145,7 @@ class ResponseTestCase(unittest.TestCase):
                     rtol=1E-2, atol=2E-2)
 
     def test_get_response_per_stage(self):
-        filenames = ["IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
+        filenames = ["AU.MEEK", "IRIS_single_channel_with_response", "XM.05", "IU_ANMO_00_BHZ"]
 
         for filename in filenames:
             xml_filename = os.path.join(self.data_dir,
@@ -154,12 +154,12 @@ class ResponseTestCase(unittest.TestCase):
             resp = inv[0][0][0].response
 
             freqs = np.logspace(-2, 2, 1000)
+            print(xml_filename, '\n', resp.response_stages)
             for x in range(1, len(resp.response_stages)):
-                print(xml_filename, '\n', resp.response_stages[x])
                 xml_resp = resp.get_evalresp_response_for_frequencies(
-                    frequencies=freqs, start_stage=x, end_stage=x+1)
+                    frequencies=freqs, start_stage=x, end_stage=x)
                 new_resp = resp.get_response(
-                    frequencies=freqs, start_stage=x, end_stage=x+1)
+                    frequencies=freqs, start_stage=x, end_stage=x)
 
                 np.testing.assert_allclose(np.abs(xml_resp),
                                            np.abs(new_resp), rtol=1E-5)
@@ -170,6 +170,8 @@ class ResponseTestCase(unittest.TestCase):
                     np.unwrap(np.angle(xml_resp))[:800],
                     np.unwrap(np.angle(new_resp))[:800],
                     rtol=1E-2, atol=2E-2)
+
+                print("Succeeded with case for stage no.", x)
 
 
 

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2876,8 +2876,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # calculate and apply frequency response,
         # optionally prefilter in frequency domain and/or apply water level
         freq_response, freqs = \
-            response.get_evalresp_response(self.stats.delta, nfft,
-                                           output=output, **kwargs)
+            response.get_response_for_window_size(self.stats.delta, nfft,
+                                                  output=output, **kwargs)
 
         if plot:
             ax1.loglog(freqs, np.abs(data), color=color1, zorder=9)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2881,7 +2881,8 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # optionally prefilter in frequency domain and/or apply water level
         freq_response, freqs = \
             response.get_response_for_window_size(self.stats.delta, nfft,
-                                                  output=output, **kwargs)
+                                                  output=output, fast=fast,
+                                                  **kwargs)
 
         if plot:
             ax1.loglog(freqs, np.abs(data), color=color1, zorder=9)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2642,8 +2642,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
     @_add_processing_info
     def remove_response(self, inventory=None, output="VEL", water_level=60,
-                        pre_filt=None, zero_mean=True, fast=True, taper=True,
-                        taper_fraction=0.05, plot=False, fig=None, **kwargs):
+                        pre_filt=None, zero_mean=True, taper=True,
+                        taper_fraction=0.05,
+                        n_frequencies_limit_for_interp=10000,
+                        plot=False, fig=None, **kwargs):
         """
         Deconvolve instrument response.
 
@@ -2749,15 +2751,18 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type zero_mean: bool
         :param zero_mean: If `True`, the mean of the waveform data is
             subtracted in time domain prior to deconvolution.
-        :type fast: bool
-        :param fast: When set to True (default), then the calculation of the
-            response for a large number of frequencies is sped up through
-            interpolation. Relevant for traces with >10000 samples.
         :type taper: bool
         :param taper: If `True`, a cosine taper is applied to the waveform data
             in time domain prior to deconvolution.
         :type taper_fraction: float
         :param taper_fraction: Taper fraction of cosine taper to use.
+        :type n_frequencies_limit_for_interp: int
+        :param n_frequencies_limit_for_interp: Indicates a limit for the number
+            of frequencies (=number of samples in a trace) for which the
+            response curve is calculated. Above this number of frequencies, the
+            response curve is interpolated. Speeds up response-calculation for
+            traces with many samples, e.g., >10000. Set to None to avoid all
+            interpolation.
         :type plot: bool or str
         :param plot: If `True`, brings up a plot that illustrates how the
             data are processed in the frequency domain in three steps. First by
@@ -2880,9 +2885,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         # calculate and apply frequency response,
         # optionally prefilter in frequency domain and/or apply water level
         freq_response, freqs = \
-            response.get_response_for_window_size(self.stats.delta, nfft,
-                                                  output=output, fast=fast,
-                                                  **kwargs)
+            response.get_response_for_window_size(
+                self.stats.delta, nfft, output=output,
+                n_frequencies_limit_for_interp=n_frequencies_limit_for_interp,
+                **kwargs)
 
         if plot:
             ax1.loglog(freqs, np.abs(data), color=color1, zorder=9)

--- a/obspy/core/trace.py
+++ b/obspy/core/trace.py
@@ -2642,7 +2642,7 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
 
     @_add_processing_info
     def remove_response(self, inventory=None, output="VEL", water_level=60,
-                        pre_filt=None, zero_mean=True, taper=True,
+                        pre_filt=None, zero_mean=True, fast=True, taper=True,
                         taper_fraction=0.05, plot=False, fig=None, **kwargs):
         """
         Deconvolve instrument response.
@@ -2749,6 +2749,10 @@ seismometer_correction_simulation.html#using-a-resp-file>`_.
         :type zero_mean: bool
         :param zero_mean: If `True`, the mean of the waveform data is
             subtracted in time domain prior to deconvolution.
+        :type fast: bool
+        :param fast: When set to True (default), then the calculation of the
+            response for a large number of frequencies is sped up through
+            interpolation. Relevant for traces with >10000 samples.
         :type taper: bool
         :param taper: If `True`, a cosine taper is applied to the waveform data
             in time domain prior to deconvolution.

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -762,7 +762,7 @@ def estimate_wood_anderson_amplitude_using_response(response, amplitude,
     """
     freq = 1.0 / (2 * timespan)
     wa_ampl = amplitude / 2.0  # half peak to peak amplitude
-    response = response.get_evalresp_response_for_frequencies(
+    response = response.get_response(
         [freq], output="VEL", start_stage=None, end_stage=None)[0]
     response_amplitude = np.absolute(response)
     wa_ampl /= response_amplitude

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -381,26 +381,31 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
         a = [1.0]
     # this turns the paz values into an IIR specification, so we will
     # use the IIR conversion method to produce the response
-    return iir_to_freq_resp(b, a, t_samp, nfft, frequencies, freq)
+    return digital_filter_to_freq_resp(b, a, t_samp, nfft, frequencies, freq)
 
 
-def iir_to_freq_resp(numer, denom, t_samp=None, nfft=None,
-                     frequencies=None, freq=False):
-    if frequencies is None:
-        n = nfft // 2
-        fy = 1 / (t_samp * 2.0)
-        # start at zero to get zero for offset / DC of fft
-        f = np.linspace(0, fy, n + 1)
-    else:
-        f = frequencies
-    _w, h = scipy.signal.freqs(numer, denom, f * 2 * np.pi)
-    if freq:
-        return h, f
-    return h
+def digital_filter_to_freq_resp(numer, denom, t_samp=None, nfft=None,
+                                frequencies=None, freq=False):
+    """
+    Convert a digital filter to frequency response.
 
+    The output contains the frequency zero which is the offset of the trace.
 
-def fir_to_freq_resp(numer, denom, t_samp=None, nfft=None,
-                         frequencies=None, freq=False):
+    :type numer: list of complex
+    :param numer: The numerator of a linear filter as coefficients
+    :type denom: list of complex
+    :param denom: The denominator of a linear filter as coefficients
+    :type t_samp: float
+    :param t_samp: Sampling interval in seconds
+    :type nfft: int
+    :param nfft: Number of FFT points of signal which needs correction
+    :type frequencies: list of float
+    :param frequencies: Discrete frequencies to get resp values for.
+    :type freq: bool
+    :param freq: If true, returns tuple of resp result with freq array input (i.e., x-values)
+    :rtype: :class:`numpy.ndarray` complex128
+    :return: Frequency response of PAZ of length nfft
+    """
     if frequencies is None:
         n = nfft // 2
         fy = 1 / (t_samp * 2.0)

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -381,11 +381,11 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
         a = [1.0]
     # this turns the paz values into an IIR specification, so we will
     # use the IIR conversion method to produce the response
-    return iir_to_freq_response(b, a, t_samp, nfft, frequencies, freq)
+    return iir_to_freq_resp(b, a, t_samp, nfft, frequencies, freq)
 
 
-def iir_to_freq_response(numer, denom, t_samp=None, nfft=None,
-                         frequencies=None, freq=False):
+def iir_to_freq_resp(numer, denom, t_samp=None, nfft=None,
+                     frequencies=None, freq=False):
     if frequencies is None:
         n = nfft // 2
         fy = 1 / (t_samp * 2.0)
@@ -399,7 +399,7 @@ def iir_to_freq_response(numer, denom, t_samp=None, nfft=None,
     return h
 
 
-def fir_to_freq_response(numer, denom, t_samp=None, nfft=None,
+def fir_to_freq_resp(numer, denom, t_samp=None, nfft=None,
                          frequencies=None, freq=False):
     if frequencies is None:
         n = nfft // 2

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -350,7 +350,8 @@ def corn_freq_2_paz(fc, damp=0.707):
     return {'poles': poles, 'zeros': [0j, 0j], 'gain': 1, 'sensitivity': 1.0}
 
 
-def paz_to_freq_resp(poles, zeros, scale_fac, t_samp, nfft, freq=False):
+def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
+                     frequencies=None, freq=False):
     """
     Convert Poles and Zeros (PAZ) to frequency response.
 
@@ -366,18 +367,26 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp, nfft, freq=False):
     :param t_samp: Sampling interval in seconds
     :type nfft: int
     :param nfft: Number of FFT points of signal which needs correction
+    :type frequencies: list of float
+    :param frequencies: Discrete frequencies to get resp values for.
+    :type freq: bool
+    :param freq: If true, returns tuple of resp result with freq array input (i.e., x-values)
     :rtype: :class:`numpy.ndarray` complex128
     :return: Frequency response of PAZ of length nfft
     """
-    n = nfft // 2
     b, a = scipy.signal.ltisys.zpk2tf(zeros, poles, scale_fac)
     # a has to be a list for the scipy.signal.freqs() call later but zpk2tf()
     # strangely returns it as an integer.
     if not isinstance(a, np.ndarray) and a == 1.0:
         a = [1.0]
-    fy = 1 / (t_samp * 2.0)
-    # start at zero to get zero for offset / DC of fft
-    f = np.linspace(0, fy, n + 1)
+
+    if frequencies is None:
+        n = nfft // 2
+        fy = 1 / (t_samp * 2.0)
+        # start at zero to get zero for offset / DC of fft
+        f = np.linspace(0, fy, n + 1)
+    else:
+        f = frequencies
     _w, h = scipy.signal.freqs(b, a, f * 2 * np.pi)
     if freq:
         return h, f

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -379,7 +379,13 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
     # strangely returns it as an integer.
     if not isinstance(a, np.ndarray) and a == 1.0:
         a = [1.0]
+    # this turns the paz values into an IIR specification, so we will
+    # use the IIR conversion method to produce the response
+    return iir_to_freq_response(b, a, t_samp, nfft, frequencies, freq)
 
+
+def iir_to_freq_response(numer, denom, t_samp=None, nfft=None,
+                         frequencies=None, freq=False):
     if frequencies is None:
         n = nfft // 2
         fy = 1 / (t_samp * 2.0)
@@ -387,7 +393,22 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
         f = np.linspace(0, fy, n + 1)
     else:
         f = frequencies
-    _w, h = scipy.signal.freqs(b, a, f * 2 * np.pi)
+    _w, h = scipy.signal.freqs(numer, denom, f * 2 * np.pi)
+    if freq:
+        return h, f
+    return h
+
+
+def fir_to_freq_response(numer, denom, t_samp=None, nfft=None,
+                         frequencies=None, freq=False):
+    if frequencies is None:
+        n = nfft // 2
+        fy = 1 / (t_samp * 2.0)
+        # start at zero to get zero for offset / DC of fft
+        f = np.linspace(0, fy, n + 1)
+    else:
+        f = frequencies
+    _w, h = scipy.signal.freqz(numer, denom, f * 2 * np.pi)
     if freq:
         return h, f
     return h

--- a/obspy/signal/invsim.py
+++ b/obspy/signal/invsim.py
@@ -366,9 +366,13 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
     :type t_samp: float
     :param t_samp: Sampling interval in seconds
     :type nfft: int
-    :param nfft: Number of FFT points of signal which needs correction
+    :param nfft: Number of FFT points of signal which needs correction.
+        If not specified, the length of the frequencies parameter will be used.
+        If specified, the value t_samp is required.
+        If the frequencies parameter is specified, both this and t_samp are ignored.
     :type frequencies: list of float
     :param frequencies: Discrete frequencies to get resp values for.
+        If nfft and t_samp are not specified, this value is required.
     :type freq: bool
     :param freq: If true, returns tuple of resp result with freq array input (i.e., x-values)
     :rtype: :class:`numpy.ndarray` complex128
@@ -379,9 +383,17 @@ def paz_to_freq_resp(poles, zeros, scale_fac, t_samp=None, nfft=None,
     # strangely returns it as an integer.
     if not isinstance(a, np.ndarray) and a == 1.0:
         a = [1.0]
-    # this turns the paz values into an IIR specification, so we will
-    # use the IIR conversion method to produce the response
-    return digital_filter_to_freq_resp(b, a, t_samp, nfft, frequencies, freq)
+    if frequencies is None:
+        n = nfft // 2
+        fy = 1 / (t_samp * 2.0)
+        # start at zero to get zero for offset / DC of fft
+        f = np.linspace(0, fy, n + 1)
+    else:
+        f = frequencies
+    _w, h = scipy.signal.freqs(b, a, f * 2 * np.pi)
+    if freq:
+        return h, f
+    return h
 
 
 def digital_filter_to_freq_resp(numer, denom, t_samp=None, nfft=None,
@@ -398,13 +410,17 @@ def digital_filter_to_freq_resp(numer, denom, t_samp=None, nfft=None,
     :type t_samp: float
     :param t_samp: Sampling interval in seconds
     :type nfft: int
-    :param nfft: Number of FFT points of signal which needs correction
+    :param nfft: Number of FFT points of signal which needs correction.
+        If not specified, the length of the frequencies parameter will be used.
+        If specified, the value t_samp is required.
+        If the frequencies parameter is specified, both this and t_samp are ignored.
     :type frequencies: list of float
     :param frequencies: Discrete frequencies to get resp values for.
+        If nfft and t_samp are not specified, this value is required.
     :type freq: bool
     :param freq: If true, returns tuple of resp result with freq array input (i.e., x-values)
     :rtype: :class:`numpy.ndarray` complex128
-    :return: Frequency response of PAZ of length nfft
+    :return: Frequency response of filter of length nfft
     """
     if frequencies is None:
         n = nfft // 2

--- a/obspy/signal/spectral_estimation.py
+++ b/obspy/signal/spectral_estimation.py
@@ -1260,7 +1260,7 @@ class PPSD(object):
     def _get_response_from_inventory(self, tr):
         inventory = self.metadata
         response = inventory.get_response(self.id, tr.stats.starttime)
-        resp, _ = response.get_evalresp_response(
+        resp, _ = response.get_response_for_window_size(
             t_samp=self.delta, nfft=self.nfft, output="VEL")
         return resp
 


### PR DESCRIPTION
### What does this PR do?
This PR implements the changes suggested by @krischer here https://github.com/obspy/obspy/pull/2592#issuecomment-659005117:

### Why was it initiated?  Any relevant Issues?
This PR build on top of this PR: https://github.com/amkearns-usgs/obspy/pull/4, but as that PR is already merged, I have to reopen the PR here.


>  1. I think instead of having a boolean flag `fast` it would be useful to specify the maximum number of frequencies to calculate it at. This would allow tuning it to the problem at hand. The current 10k is likely a sane default.

I changed the `fast=True` to a value `n_frequencies_limit_for_interp=10000` now. If you can think of a better, and self-explanatory name of that variable, please let me know ;-)



>  2. I don't really have a good feeling for this but maybe computing the original response points using `np.logspace()` might be advantageous?

I changed it to logspace. I guess in my head I was mostly concerned how well logspace would be able to represent the high-amplitude response, e.g., due to FIR filter around the Nyquistfrequency (see, e.g., [the phase-response here](http://service.iris.edu/irisws/evalresp/1/query?net=IU&sta=ANMO&loc=10&cha=HHZ&time=2019-06-07T20:00:01&width=800&height=600&output=plot&annotate=true). But I think as you both noted the low frequencies may be quite inaccurately represented with linspace. And with a default of n=10000, logspace should be good enough also at the high frequencies.

> Very much yes from my side! Interesting that the interpolation happens on amplitude and phase and not directly on the complex numbers but I guess this makes sense because the curve is smooth in these two.

This also replicates how interpolation was done in evalresp. But it's a good point to check, as the interpolation becomes the computationally most expensive call once interpolation is chosen. In `InterpolatedUnivariateSpline(resp_frequencies, amp, k=3)(frequencies)` I changed to `k=2` to best replicate the original interpolation chosen in evalresp, which was CubicSpline interpolation.

### PR Checklist
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGELOG.txt` .
- [ ] First time contributors have added your name to `CONTRIBUTORS.txt` .
